### PR TITLE
Reduce needless fetch stalls in presence of compressed instructions

### DIFF
--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -309,7 +309,7 @@ module mkCore#(CoreId coreId)(Core);
                 let train <- toGet(trainBPQ[i]).get;
                 fetchStage.train_predictors(
                     train.pc, train.nextPc, train.iType, train.taken,
-                    train.dpTrain, train.mispred
+                    train.dpTrain, train.mispred, train.isCompressed
                 );
             endrule
         end

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -78,6 +78,7 @@ typedef struct {
     Maybe#(PhyDst) dst;
     InstTag tag;
     DirPredTrainInfo dpTrain;
+    Bool isCompressed;
     // result
     Data data; // alu compute result
     Maybe#(Data) csrData; // data to write CSR file
@@ -123,6 +124,7 @@ typedef struct {
     Bool taken;
     DirPredTrainInfo dpTrain;
     Bool mispred;
+    Bool isCompressed;
 } FetchTrainBP deriving(Bits, Eq, FShow);
 
 interface AluExeInput;
@@ -291,6 +293,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
                 dst: x.dst,
                 tag: x.tag,
                 dpTrain: x.dpTrain,
+                isCompressed: x.orig_inst[1:0] != 2'b11,
                 data: exec_result.data,
                 csrData: isValid(x.dInst.csr) ? Valid (exec_result.csrData) : Invalid,
                 controlFlow: exec_result.controlFlow,
@@ -333,7 +336,8 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
                 iType: x.iType,
                 taken: x.controlFlow.taken,
                 dpTrain: x.dpTrain,
-                mispred: True
+                mispred: True,
+                isCompressed: x.isCompressed
             });
 `ifdef PERF_COUNT
             // performance counter
@@ -361,7 +365,8 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
                     iType: x.iType,
                     taken: x.controlFlow.taken,
                     dpTrain: x.dpTrain,
-                    mispred: False
+                    mispred: False,
+                    isCompressed: x.isCompressed
                 });
             end
         end

--- a/src_Core/RISCY_OOO/procs/lib/Btb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Btb.bsv
@@ -31,8 +31,8 @@ export NextAddrPred(..);
 export mkBtb;
 
 interface NextAddrPred;
-    method Addr predPc(Addr pc);
-    method Action update(Addr pc, Addr nextPc, Bool taken);
+    method Maybe#(Addr) predPc(Addr pc);
+    method Action update(Addr pc, Addr brTarget, Bool taken);
     // security
     method Action flush;
     method Bool flush_done;
@@ -96,13 +96,13 @@ module mkBtb(NextAddrPred);
     endrule
 `endif
 
-    method Addr predPc(Addr pc);
+    method Maybe#(Addr) predPc(Addr pc);
         BtbIndex index = getIndex(pc);
         BtbTag tag = getTag(pc);
         if(valid[index] && tag == tags.sub(index))
-            return next_addrs.sub(index);
+            return tagged Valid next_addrs.sub(index);
         else
-            return (pc + 4);
+            return tagged Invalid;
     endmethod
 
     method Action update(Addr pc, Addr nextPc, Bool taken);


### PR DESCRIPTION
Currently, our next address prediction cannot distinguish between a
taken compressed branch to PC+4 and an uncompressed instruction that
falls through. We can instead make the NAP machinery much more robust by
keying it on the 16b parcels, with uncompressed branches having their
taken prediction on the second 16b parcel. This also removes the need
for the address prediction requests to be chained.

Moreover, if we decode more than 2 instructions in one cycle due to
decompression, we throw away any subsequent instructions and treat it
like a branch miss, redirecting and thus restarting the pipeline from
the first discarded PC. We should therefore instead save them for
issuing on the next cycle and avoid the redirects. To ensure we don't
needlessly reduce our IPC, if we have a partial issue's width of
instructions saved, we should also support issuing instructions from the
next ICache response if valid, which should be the case in hot
correctly-predicted code paths, especially tight loops. As part of this
change, we also keep the pending straddle state in Fetch3 rather than
sending it to Decode only to have it be forwarded back.

Combined, these two approaches ensure the fetch unit can maintain an IPC
of 2 after it has had time to be correctly trained, regardless of the
distribution of compressed instructions.