### PR TITLE
RenameStage.bsv: Fix single-step when only one instruction available

### DIFF
--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/RenameStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/RenameStage.bsv
@@ -843,13 +843,6 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
 
                 Addr fallthrough_pc = ((orig_inst[1:0] == 2'b11) ? pc + 4 : pc + 2);
 
-`ifdef INCLUDE_GDB_CONTROL
-	        if ((i != 0) && (csrf.dcsr_step_bit == 1'b1)) begin
-		   stop       = True;
-		   debug_step = True;
-		end
-`endif
-
                 // check for wrong path, if wrong path, don't process it, leave to the other rule in next cycle
                 if(!epochManager.checkEpoch[i].check(main_epoch)) begin
                     stop = True;
@@ -1104,6 +1097,13 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
                         if(spec_tag matches tagged Valid .t) begin
                             spec_bits = spec_bits | (1 << t);
                         end
+
+`ifdef INCLUDE_GDB_CONTROL
+                        if ((i == 0) && (csrf.dcsr_step_bit == 1'b1)) begin
+                            stop       = True;
+                            debug_step = True;
+                        end
+`endif
                     end
                 end
             end


### PR DESCRIPTION
If we never look at the second instruction in the FIFO from the fetch
unit when successfully renaming the first, we do not end up setting
debug_step and thus we will not halt on the next instruction but some
time later. Instead, check for single-stepping at the end of renaming
the first instruction.