### PR TITLE
Ifetch cleanup master

### DIFF
--- a/builds/Resources/Include_bluesim.mk
+++ b/builds/Resources/Include_bluesim.mk
@@ -24,7 +24,6 @@ compile: build_dir
 SIM_EXE_FILE = exe_HW_sim
 
 BSC_C_FLAGS += \
-	-Xc++  -D_GLIBCXX_USE_CXX11_ABI=0 \
 	-Xl -v \
 	-Xc -O1 -Xc++ -O1 \
 

--- a/src_Core/CPU/MMIOPlatform.bsv
+++ b/src_Core/CPU/MMIOPlatform.bsv
@@ -1,7 +1,7 @@
 
 // Copyright (c) 2018 Massachusetts Institute of Technology
 // Portions (c) 2019-2020 Bluespec, Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -9,10 +9,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -171,7 +171,7 @@ function Bit #(64) fn_amo_op (Bit #(2)   sz,        // encodes data size (.W or 
    Bit #(64) w1     = fn_extract_and_extend_bytes (sz, addr, ld_val);
    Bit #(64) w2     = fn_extract_and_extend_bytes (sz, addr, st_val);
 
-   
+
    // Do AMO op
    Int #(64) i1     = unpack (w1);    // Signed, for signed ops
    Int #(64) i2     = unpack (w2);    // Signed, for signed ops
@@ -265,10 +265,10 @@ module mkMMIOPlatform #(Vector#(CoreNum, MMIOCoreToPlatform) cores,
    // offset of the requested inst within a Data
    Reg#(DataInstOffset) instSel <- mkRegU;
    // the current superscaler way being fetched
-   Reg#(SupWaySel) fetchingWay <- mkRegU;
+   Reg#(SupWayX2Sel) fetchingWay <- mkRegU;
    // the already fetched insts
-   Vector#(TSub#(SupSize, 1),
-	   Reg#(Instruction)) fetchedInsts <- replicateM(mkRegU);
+   Vector#(TSub#(SupSizeX2, 1),
+           Reg#(Instruction16)) fetchedInsts <- replicateM(mkRegU);
 
    // we need to wait for resp from cores when we need to change MTIP
    Reg#(Vector#(CoreNum, Bool)) waitMTIPCRs <- mkRegU;
@@ -518,7 +518,7 @@ module mkMMIOPlatform #(Vector#(CoreNum, MMIOCoreToPlatform) cores,
 	    cores[upper_core].pRq.enq(MMIOPRq {
 	       target: MSIP,
 	       func: reqFunc,
-	       data: zeroExtend(reqData[32]) 
+	       data: zeroExtend(reqData[32])
 	       });
          end
          state <= WaitResp;
@@ -1005,21 +1005,33 @@ module mkMMIOPlatform #(Vector#(CoreNum, MMIOCoreToPlatform) cores,
 	 $display ("    ", fshow (req));
       end
    endrule
-
+/*
+   function Vector #(SupSizeX2, Maybe #(Instruction16)) prepareFinalInstResp(Vector #(SupSize, Maybe #(Instruction)) respBigInsts, Bit#(1) addr_bit_1);
+       Vector #(SupSizeX2, Maybe #(Instruction16)) respSmallInsts = replicate (Invalid);
+       for (Integer i = 0; i < valueOf (SupSize); i = i+1) begin
+          if (respBigInsts[i] matches tagged Valid .inst) begin
+              respSmallInsts[i*2]       = tagged Valid (truncate(inst));
+              respSmallInsts[(i*2) + 1] = tagged Valid (truncateLSB(inst));
+          end
+       end
+       // This unconventional zero-extension of addr_bit_1 works around a type error in shiftOutFrom0.
+       return shiftOutFrom0(Invalid, respSmallInsts, {4'b0, addr_bit_1});
+   endfunction
+*/
    rule rl_mmio_from_fabric_ifetch_rsp (curReq matches tagged MMIO_Fabric_Adapter .addr
 					&&& (state == WaitResp)
 					&&& isInstFetch);
       MMIODataPRs dprs <- mmio_fabric_adapter_core_side.response.get;
       if (! dprs.valid) begin
-	 // Access fault
-         Vector #(SupSize, Maybe #(Instruction)) resp = replicate (Invalid);
-         for(Integer i = 0; i < valueof (SupSize); i = i+1) begin
-	    if (fromInteger (i) < fetchingWay)
-	       resp [i] = Valid (fetchedInsts [i]);
+         // Access fault
+         Vector #(SupSizeX2, Maybe #(Instruction16)) resp = replicate (Invalid);
+         for(Integer i = 0; i < valueof (SupSizeX2); i = i+1) begin
+            if (fromInteger (i) < fetchingWay)
+               resp [i] = Valid (fetchedInsts [i]);
             else if (fromInteger (i) == fetchingWay)
 	       resp [i] = tagged Invalid;
          end
-         cores[reqCore].pRs.enq (tagged InstFetch (resp));
+         cores[reqCore].pRs.enq (tagged InstFetch resp);
          state <= SelectReq;
 
 	 if (verbosity > 0) begin
@@ -1032,28 +1044,26 @@ module mkMMIOPlatform #(Vector#(CoreNum, MMIOCoreToPlatform) cores,
 	 // No access fault
 	 let data = dprs.data;
 
-         SupWaySel maxWay = 0;
+         SupWayX2Sel maxWay = 0;
          if(reqFunc matches tagged Inst .w) begin
             maxWay = w;
          end
 
-	 // View Data as a vector of instructions
-         Vector#(DataSzInst, Instruction) instVec = unpack(data);
+         // View Data as a vector of instructions
+         Vector#(MemDataSzInst, Instruction16) instVec = unpack(pack(dprs.data));
          // extract inst from resp data
-         Instruction inst = instVec[instSel];
+         Instruction16 inst = instVec[instSel];
          // check whether we are done or not
          if (fetchingWay >= maxWay) begin
-	    // all 0..maxWay insts are fetched; we can resp now
-            Vector#(SupSize, Maybe#(Instruction)) resp = replicate(Invalid);
-            for(Integer i = 0; i < valueof(SupSize); i = i+1) begin
-	       if(fromInteger(i) < fetchingWay) begin
+            // all 0..maxWay insts are fetched; we can resp now
+            Vector#(SupSizeX2, Maybe#(Instruction16)) resp = replicate(Invalid);
+            for(Integer i = 0; i < valueof(SupSizeX2); i = i+1) begin
+               if(fromInteger(i) < fetchingWay)
                   resp[i] = Valid (fetchedInsts[i]);
-	       end
-               else if(fromInteger(i) == fetchingWay) begin
+               else if(fromInteger(i) == fetchingWay)
                   resp[i] = Valid (inst);
-		  end
-               end
-            cores[reqCore].pRs.enq (tagged InstFetch (resp));
+            end
+            cores[reqCore].pRs.enq (tagged InstFetch resp);
             state <= SelectReq;
 
 	    if (verbosity > 0) begin

--- a/src_Core/CPU/MMIOPlatform.bsv
+++ b/src_Core/CPU/MMIOPlatform.bsv
@@ -33,7 +33,6 @@ import GetPut::*;
 import ClientServer::*;
 import Connectable::*;
 import FIFOF     :: *;
-// import BRAMCore::*;
 
 // ----------------
 // BSV additional libs
@@ -1005,19 +1004,7 @@ module mkMMIOPlatform #(Vector#(CoreNum, MMIOCoreToPlatform) cores,
 	 $display ("    ", fshow (req));
       end
    endrule
-/*
-   function Vector #(SupSizeX2, Maybe #(Instruction16)) prepareFinalInstResp(Vector #(SupSize, Maybe #(Instruction)) respBigInsts, Bit#(1) addr_bit_1);
-       Vector #(SupSizeX2, Maybe #(Instruction16)) respSmallInsts = replicate (Invalid);
-       for (Integer i = 0; i < valueOf (SupSize); i = i+1) begin
-          if (respBigInsts[i] matches tagged Valid .inst) begin
-              respSmallInsts[i*2]       = tagged Valid (truncate(inst));
-              respSmallInsts[(i*2) + 1] = tagged Valid (truncateLSB(inst));
-          end
-       end
-       // This unconventional zero-extension of addr_bit_1 works around a type error in shiftOutFrom0.
-       return shiftOutFrom0(Invalid, respSmallInsts, {4'b0, addr_bit_1});
-   endfunction
-*/
+
    rule rl_mmio_from_fabric_ifetch_rsp (curReq matches tagged MMIO_Fabric_Adapter .addr
 					&&& (state == WaitResp)
 					&&& isInstFetch);

--- a/src_Core/CPU/MMIO_AXI4_Adapter.bsv
+++ b/src_Core/CPU/MMIO_AXI4_Adapter.bsv
@@ -171,7 +171,7 @@ module mkMMIO_AXI4_Adapter (MMIO_AXI4_Adapter_IFC);
       // Technically the following check for legal IO addrs is not
       // necessary; the AXI4 fabric should return a DECERR for illegal
       // addrs; but not all AXI4 fabrics do the right thing.
-      if (soc_map.m_is_IO_addr (req.addr))
+      if (soc_map.m_is_IO_addr (req.addr, False))
 	 fa_fabric_send_read_req (req.addr);
       else begin
 	 let rsp = MMIODataPRs {valid: False,
@@ -222,7 +222,7 @@ module mkMMIO_AXI4_Adapter (MMIO_AXI4_Adapter_IFC);
       // Technically the following check for legal IO addrs is not
       // necessary; the AXI4 fabric should return a DECERR for illegal
       // addrs; but not all AXI4 fabrics do the right thing.
-      if (soc_map.m_is_IO_addr (req.addr))
+      if (soc_map.m_is_IO_addr (req.addr, False))
 	 fa_fabric_send_write_req (req.addr, pack (req.byteEn), req.data);
       else begin
 	 let rsp = MMIODataPRs {valid: False,

--- a/src_Core/CPU/MMIO_AXI4_Adapter.bsv
+++ b/src_Core/CPU/MMIO_AXI4_Adapter.bsv
@@ -262,10 +262,7 @@ module mkMMIO_AXI4_Adapter (MMIO_AXI4_Adapter_IFC);
 	 $display ("    ", fshow (wr_resp));
 	 $finish (1);
       end
-      else begin
-	 let rsp = MMIODataPRs {valid: True, data: 0};
-	 f_rsps_to_core.enq (rsp);
-      end
+      f_rsps_to_core.enq (MMIODataPRs {valid: wr_resp.bresp == axi4_resp_okay, data: 0});
    endrule
 
    // ================================================================

--- a/src_Core/RISCY_OOO/coherence/src/CCTypes.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/CCTypes.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -32,9 +32,9 @@ import GetPut::*;
 import ClientServer::*;
 
 typedef enum {
-    I = 2'd0, 
-    S = 2'd1, 
-    E = 2'd2, 
+    I = 2'd0,
+    S = 2'd1,
+    E = 2'd2,
     M = 2'd3
 } MESI deriving(Bits, Eq, FShow);
 typedef MESI Msi;
@@ -79,7 +79,7 @@ typedef TDiv#(DataSz, 8) DataSzBytes;
 typedef TLog#(DataSzBytes) LgDataSzBytes;
 typedef Bit#(LgDataSzBytes) DataBytesOffset;
 
-typedef TDiv#(InstSz, 8) InstSzBytes;
+typedef TDiv#(Inst16_Sz, 8) InstSzBytes;
 typedef TLog#(InstSzBytes) LgInstSzBytes;
 
 // 64B cache line -- XXX same with parameters in CacheUtils.bsv
@@ -118,7 +118,7 @@ function Line getUpdatedLine(Line curLine, LineByteEn wrBE, Line wrLine);
     Vector#(LineSzBytes, Bit#(8)) newVec = map(getNewByte, genVector);
     return unpack(pack(newVec));
 endfunction
- 
+
 function Data getUpdatedData(Data curData, ByteEn wrBE, Data wrData);
     Vector#(DataSzBytes, Bit#(8)) curVec = unpack(pack(curData));
     Vector#(DataSzBytes, Bit#(8)) wrVec = unpack(pack(wrData));
@@ -221,7 +221,7 @@ typedef struct {
 // I$ req/resp
 interface InstServer#(numeric type supSz);
     interface Put#(Addr) req;
-    interface Get#(Vector#(supSz, Maybe#(Instruction))) resp;
+    interface Get#(Vector#(TMul#(supSz,2), Maybe#(Instruction16))) resp;
 `ifdef DEBUG_ICACHE
     interface Get#(DebugICacheResp) done; // the id and cache line of the I$ req that truly performs
 `endif
@@ -371,7 +371,7 @@ endinterface
 
 instance Connectable#(MemFifoServer#(idT, childT), MemFifoClient#(idT, childT));
     module mkConnection#(
-        MemFifoServer#(idT, childT) server, 
+        MemFifoServer#(idT, childT) server,
         MemFifoClient#(idT, childT) client
     )(Empty);
         rule doCToM;

--- a/src_Core/RISCY_OOO/coherence/src/SelfInvIBank.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/SelfInvIBank.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -109,7 +109,8 @@ module mkSelfInvIBank#(
     Alias#(cRqSlotT, ICRqSlot#(wayT, tagT)), // cRq MSHR slot
     Alias#(iCmdT, SelfInvICmd#(cRqIdxT)),
     Alias#(pipeOutT, PipeOut#(wayT, tagT, Msi, void, cacheOwnerT, otherT, RandRepInfo, Line, iCmdT)),
-    Alias#(resultT, Vector#(supSz, Maybe#(Instruction))),
+    Mul#(2, supSz, supSzX2),
+    Alias#(resultT, Vector#(supSzX2, Maybe#(Instruction16))),
     // requirements
     FShow#(pipeOutT),
     Add#(tagSz, a__, AddrSz),
@@ -133,7 +134,7 @@ module mkSelfInvIBank#(
 
     // index Q to order all in flight cRq for in-order resp
     FIFO#(cRqIdxT) cRqIndexQ <- mkSizedFIFO(valueof(cRqNum));
-   
+
     // Reconcile states
     Reg#(Bool) needReconcile <- mkReg(False);
     Reg#(Bool) waitReconcileDone <- mkReg(False);
@@ -143,7 +144,7 @@ module mkSelfInvIBank#(
     Reg#(Bit#(64)) cRqId <- mkReg(0);
     // FIFO to signal the id of cRq that is performed
     // FIFO has 0 cycle latency to match L1 D$ resp latency
-    Fifo#(1, DebugICacheResp) cRqDoneQ <- mkBypassFifo; 
+    Fifo#(1, DebugICacheResp) cRqDoneQ <- mkBypassFifo;
 `endif
 
 `ifdef PERF_COUNT
@@ -231,7 +232,7 @@ module mkSelfInvIBank#(
         $display("%t I %m pRsTransfer: ", $time, fshow(resp));
         doAssert(resp.toState == S && isValid(resp.data), "I$ must upgrade to S with data");
     endrule
-    
+
     rule sendRqToP;
         rqToPIndexQ.deq;
         cRqIdxT n = rqToPIndexQ.first;
@@ -247,10 +248,10 @@ module mkSelfInvIBank#(
         };
         rqToPQ.enq(cRqToP);
        if (verbose)
-        $display("%t I %m sendRqToP: ", $time, 
-            fshow(n), " ; ", 
-            fshow(req), " ; ", 
-            fshow(slot), " ; ", 
+        $display("%t I %m sendRqToP: ", $time,
+            fshow(n), " ; ",
+            fshow(req), " ; ",
+            fshow(slot), " ; ",
             fshow(cRqToP)
         );
 `ifdef PERF_COUNT
@@ -281,14 +282,14 @@ module mkSelfInvIBank#(
 
     // function to get superscaler inst read result
     function resultT readInst(Line line, Addr addr);
-        Vector#(LineSzInst, Instruction) instVec = unpack(pack(line));
+        Vector#(LineSzInst, Instruction16) instVec = unpack(pack(line));
         // the start offset for reading inst
         LineInstOffset startSel = getLineInstOffset(addr);
         // calculate the maximum inst count that could be read from line
         LineInstOffset maxCntMinusOne = maxBound - startSel;
         // read inst superscalaer
         resultT val = ?;
-        for(Integer i = 0; i < valueof(supSz); i = i+1) begin
+        for(Integer i = 0; i < valueof(supSzX2); i = i+1) begin
             if(fromInteger(i) <= maxCntMinusOne) begin
                 LineInstOffset sel = startSel + fromInteger(i);
                 val[i] = Valid (instVec[sel]);
@@ -351,7 +352,7 @@ module mkSelfInvIBank#(
         procRqT procRq = pipeOutCRq;
        if (verbose)
         $display("%t I %m pipelineResp: cRq: ", $time, fshow(n), " ; ", fshow(procRq));
-        
+
         // find end of dependency chain
         Maybe#(cRqIdxT) cRqEOC = cRqMshr.pipelineResp.searchEndOfChain(procRq.addr);
 
@@ -367,7 +368,7 @@ module mkSelfInvIBank#(
             doAssert(ram.info.cs <= S, "no exclusive in I$");
             // This cannot be a hit
             doAssert(ram.info.cs == I || ram.info.tag != getTag(procRq.addr), "cannot hit");
-            // Thus we must send req to parent 
+            // Thus we must send req to parent
             rqToPIndexQ.enq(n);
             // update mshr
             cRqMshr.pipelineResp.setStateSlot(n, WaitSt, ICRqSlot {
@@ -538,7 +539,7 @@ module mkSelfInvIBank#(
             };
         endmethod
     endinterface
-                
+
     interface pRqStuck = nullGet;
 
 `ifdef SECURITY
@@ -646,4 +647,3 @@ endmodule
 // unsafe version: all reads read the original reg value, except sendRsToC, which should bypass from pipelineResp
 // all writes are cononicalized. NOTE: writes of sendRsToC should be after pipelineResp
 // we maintain the logical ordering in safe version
-

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -267,7 +267,7 @@ module mkFetchStage(FetchStage);
     // Pipeline Stage FIFOs
     Fifo#(2, Tuple2#(Bit#(TLog#(SupSizeX2)),Fetch1ToFetch2)) f12f2 <- mkCFFifo;
     Fifo#(4, Tuple2#(Bit#(TLog#(SupSizeX2)),Fetch2ToFetch3)) f22f3 <- mkCFFifo; // FIFO should match I$ latency
-    SupFifo#(SupSizeX2, 2, Fetch3ToDecode) f32d <- mkSupFifo;
+    SupFifo#(SupSizeX2, 3, Fetch3ToDecode) f32d <- mkSupFifo; // This fifo needs a capacity of 3 for full throughput.  Unknown why.
     SupFifo#(SupSize, 2, FromFetchStage) out_fifo <- mkSupFifo;
        // Can the fifo size be smaller?
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -623,9 +623,8 @@ module mkFetchStage(FetchStage);
             end
         end
         else if (parse_f22f3) begin
-            Vector#(SupSizeX2,Instruction16) v_x16;
-            for (Integer i=0; i<valueOf(SupSizeX2); i=i+1) v_x16[i] = fromMaybe(?,inst_d[i]);
-            SupCntX2 n_x16s = min(zeroExtend(nbSupX2In)+1, pack(countIf(isValid,inst_d)));
+            Vector#(SupSizeX2, Instruction16) v_x16 = map(fromMaybe(?), inst_d);
+            SupCntX2 n_x16s = min(zeroExtend(nbSupX2In) + 1, pack(countIf(isValid, inst_d)));
 
             // Parse v_x16 into 32-bit and 16-bit instructions
             Addr pred_next_pc;

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -140,6 +140,7 @@ typedef struct {
   Bit#(32) orig_inst;
   Inst_Kind inst_kind;
   Maybe#(Exception) cause;
+  Bool cause_second_half;
   Bool mispred_first_half;
 } InstrFromFetch3 deriving(Bits, Eq, FShow);
 
@@ -153,12 +154,15 @@ function InstrFromFetch3 fetch3_2_instC(Fetch3ToDecode in, Instruction inst, Bit
       orig_inst: orig_inst,
       inst_kind: Inst_16b,
       cause: in.cause,
+      cause_second_half: False,
       mispred_first_half: False
    };
 
 function InstrFromFetch3 fetch3s_2_inst(Fetch3ToDecode inHi, Fetch3ToDecode inLo);
    Instruction inst = {inHi.inst_frag, inLo.inst_frag};
    InstrFromFetch3 ret = fetch3_2_instC(inHi, inst, inst);
+   if (isValid(inLo.cause)) ret.cause = inLo.cause;
+   else if (isValid(inHi.cause)) ret.cause_second_half = True;
    ret.inst_kind = Inst_32b;
    ret.pc = inLo.pc; // The PC comes from the 1st fragment.
    ret.mispred_first_half = isValid(inLo.ppc); // If we predicted a jump on the first half of the 32-bit instruction, we have erred.
@@ -624,7 +628,7 @@ module mkFetchStage(FetchStage);
                                         orig_inst: in.orig_inst,
                                         regs: decode_result.regs,
                                         cause: cause,
-                                        tval: in.pc
+                                        tval: in.pc + ((in.cause_second_half) ? 2:0)
                                         };
                out_fifo.enqS[i].enq(out);
                if (verbosity >= 1) begin

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -544,11 +544,10 @@ module mkFetchStage(FetchStage);
 
             // do decode and branch prediction
             // Drop here if does not match the decode_epoch.
-
-            // We predicted a taken branch for PC, but this is an
-            // uncompressed instruction, so we redirect to this PC and
-            // train it to fetch the other half in future.
             if (in.decode_epoch == decode_epoch_local && in.mispred_first_half) begin
+               // We predicted a taken branch for PC, but this is an
+               // uncompressed instruction, so we redirect to this PC and
+               // train it to fetch the other half in future.
                if (verbose) $display("mispredicted first half in decode: pc :  %h", pc);
                decode_epoch_local = !decode_epoch_local;
                redirectPc = Valid (pc); // record redirect to the first PC in this bundle.

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -1,7 +1,7 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
 // Portions Copyright (c) 2019-2020 Bluespec, Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -9,10 +9,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -189,7 +189,6 @@ endfunction
 
 // Fetching instructions from mem returns up to superscalar-size 32b parcels, = twice that many 16b parcels
 
-typedef TMul #(SupSize, 2) SupSizeX2;
 typedef Bit #(TLog #(TAdd #(SupSizeX2, 1))) SupCntX2;
 
 // Merging up to SupSize-1 pending instructions with up to SupSizeX2 decoded
@@ -231,26 +230,11 @@ instance DefaultValue #(Inst_Item);
    };
 endinstance
 
-// Input 'inst_d' was fetched from memory: up to superscalar-size sequence of 32b parcels.
-// Convert this into 16b parcels, prior to re-parsing for possible mix of 32b and 16b instructions.
-// This is a pure function; ActionValue is used only to allow $displays for debugging.
-
-function ActionValue #(Tuple2 #(SupCntX2,
-				Vector #(SupSizeX2, Bit #(16))))
-         fav_inst_d_to_x16s (Vector #(SupSize, Maybe #(Instruction))  inst_d);
-   actionvalue
-      // Convert inst_d into 16-bit parcels (v_x16)
-      function Bit #(32) fv_x32 (Integer i) = fromMaybe (0, inst_d [i]);
-      Vector #(SupSize,   Bit #(32)) v_x32 = genWith (fv_x32);
-      Vector #(SupSizeX2, Bit #(16)) v_x16 = unpack (pack (v_x32));
-
-      // Count the number of 16b parcels (n_x16s)
-      function Bit #(1)  fv_valid (Maybe #(Instruction) inst) = (isValid (inst) ? 1 : 0);
-      SupCntX2 n_x16s = 2 * extend (pack (countOnes (pack (map (fv_valid, inst_d)))));
-
-      return tuple2 (n_x16s, v_x16);
-   endactionvalue
+typedef Tuple3 #(Addr, Bit #(16), Bool) Straddle;
+function Straddle fv_straddle (Addr pc, Bit #(16) lsbs, Bool mispred);
+    return tuple3 (pc, lsbs, mispred);
 endfunction
+typedef Maybe #(Straddle) MStraddle;
 
 // Parse 16b parcels (v_x16) into a sequence of 16b or 32b instructions.
 // This is a pure function; ActionValue is used only to allow $displays for debugging.
@@ -268,12 +252,11 @@ function ActionValue #(Tuple4 #(SupCntX2,
    actionvalue
       // Parse up to SupSizeX2 instructions (v_items) from fetched v_x16 parcels (v_x16).
       Vector #(SupSizeX2, Inst_Item) v_items = replicate (Inst_Item {pc: pc_start,
-								     inst_kind: Inst_None,
-								     orig_inst: 0,
-								     inst: 0});
-      Maybe #(Tuple3 #(Addr, Bit #(16), Bool)) next_straddle = tagged Invalid;
-      // Start parse at parcel 0/1 depending on pc lsbs.
-      SupCntX2 j  = (pc_start [1:0] == 2'b00 ? 0 : 1);
+                                                                     inst_kind: Inst_None,
+                                                                     orig_inst: 0,
+                                                                     inst: 0});
+      MStraddle next_straddle = tagged Invalid;
+      SupCntX2 j  = 0;
       Addr     pc = pc_start;
       Integer n_items = 0;
       for (Integer i = 0; i < valueOf (SupSizeX2); i = i + 1) begin
@@ -418,7 +401,7 @@ module mkFetchStage(FetchStage);
     ICoCache iMem <- mkICoCache;
     MMIOInst mmio <- mkMMIOInst;
     Server#(Addr, TlbResp) tlb_server = iTlb.to_proc;
-    Server#(Addr, Vector#(SupSize, Maybe#(Instruction))) mem_server = iMem.to_proc;
+    Server#(Addr, Vector#(SupSizeX2, Maybe#(Instruction16))) mem_server = iMem.to_proc;
 
     // performance counters
     Fifo#(1, DecStagePerfType) perfReqQ <- mkCFFifo; // perf req FIFO
@@ -448,32 +431,6 @@ module mkFetchStage(FetchStage);
     endrule
 `endif
 
-   // Predict the next fetch-PC based only on current PC (without
-   // knowing the instructions).
-
-   function ActionValue #(Tuple2 #(Integer, Maybe #(Addr))) fav_pred_next_pc (Addr pc);
-      actionvalue
-	 Addr    prev_PC      = pc;
-	 Maybe #(Addr) pred_next_pc = nextAddrPred.predPc (prev_PC);
-	 Integer posLastSupX2 = 0;
-	 Bool    done         = False;
-	 for (Integer i = 0; i < valueOf (SupSizeX2); i = i + 1) begin
-	    if (! done) begin
-	       Bool isLastX2 = (i == (valueOf (SupSizeX2) - 1)) || ((pc[1:0] != 2'b00) && (i == (valueOf (SupSizeX2) - 2)));
-	       Bool lastInstInCacheLine = (getLineInstOffset (prev_PC) == maxBound) && (prev_PC[1:0] != 2'b00);
-	       Bool isJump   = isValid(pred_next_pc);
-	       done = isLastX2 || lastInstInCacheLine || isJump;
-	       posLastSupX2 = i;
-	       if (! done) begin
-		  prev_PC      = prev_PC + 2;
-		  pred_next_pc = nextAddrPred.predPc (prev_PC);
-	       end
-	    end
-	 end
-	 return tuple2 (posLastSupX2, pred_next_pc);
-      endactionvalue
-   endfunction
-
     // We don't send req to TLB when waiting for redirect or TLB flush. Since
     // there is no FIFO between doFetch1 and TLB, when OOO commit stage wait
     // TLB idle to change VM CSR / signal flush TLB, there is no wrong path
@@ -481,37 +438,32 @@ module mkFetchStage(FetchStage);
     rule doFetch1(started && !waitForRedirect && !waitForFlush);
         let pc = pc_reg[pc_fetch1_port];
 
-       /* ORIGINAL CODE
         // Chain of prediction for the next instructions
         // We need a BTB with a register file with enough ports!
         // Instead of cascading predictions, we can always feed pc+4*i into
         // predictor, because we will break superscaler fetch if nextpc != pc+4
-        Vector#(SupSize, Addr) pred_future_pc;
-        for(Integer i = 0; i < valueof(SupSize); i = i+1) begin
-            pred_future_pc[i] = nextAddrPred.predPc(pc + fromInteger(4 * i));
+        Vector#(SupSizeX2, Maybe#(Addr)) pred_future_pc;
+        for(Integer i = 0; i < valueof(SupSizeX2); i = i+1) begin
+            pred_future_pc[i] = nextAddrPred.predPc(pc + fromInteger(2 * i));
         end
 
         // Next pc is the first nextPc that breaks the chain of pc+4 or
         // that is at the end of a cacheline.
-        Vector#(SupSize,Integer) indexes = genVector;
-        function Bool findNextPc(Addr pc, Integer i);
-            Bool notLastInst = getLineInstOffset(pc + fromInteger(4*i)) != maxBound;
-            Bool noJump = pred_future_pc[i] == pc + fromInteger(4*(i+1));
+        Vector#(SupSizeX2,Integer) indexes = genVector;
+        function Bool findNextPc(Addr p, Integer i);
+            Bool notLastInst = getLineInstOffset(p + fromInteger(2*i)) != maxBound;
+            Bool noJump = !isValid(pred_future_pc[i]);
             return (!(notLastInst && noJump));
         endfunction
-        Integer posLastSup = fromMaybe(valueof(SupSize) - 1, find(findNextPc(pc), indexes));
-        Addr pred_next_pc = pred_future_pc[posLastSup];
-        pc_reg[pc_fetch1_port] <= pred_next_pc;
-       */
+        Bit#(TLog#(SupSizeX2)) posLastSupX2 = fromInteger(fromMaybe(valueof(SupSizeX2) - 1, find(findNextPc(pc), indexes)));
+        Maybe#(Addr) pred_next_pc = pred_future_pc[posLastSupX2];
 
-        match { .posLastSupX2, .pred_next_pc } <- fav_pred_next_pc (pc);
-        let next_fetch_pc = fromMaybe(pc + 2 * (fromInteger(posLastSupX2) + 1), pred_next_pc);
+        let next_fetch_pc = fromMaybe(pc + 2 * (zeroExtend(posLastSupX2) + 1), pred_next_pc);
         pc_reg[pc_fetch1_port] <= next_fetch_pc;
 
         // Send TLB request.
-        // Mask to 32-bit alignment, even if 'C' is supported (where we may discard first 2 bytes)
-        Addr align32b_mask = 'h3;
-        tlb_server.request.put (pc & (~ align32b_mask));
+
+        tlb_server.request.put (pc);
 
         let out = Fetch1ToFetch2 {
             pc: pc,
@@ -519,9 +471,9 @@ module mkFetchStage(FetchStage);
             fetch3_epoch: fetch3_epoch,
             decode_epoch: decode_epoch[0],
             main_epoch: f_main_epoch};
-        let nbSupX2 = fromInteger(posLastSupX2) + (pc[1:0] == 2'b00 ? 0 : 1);
-        f12f2.enq(tuple2(nbSupX2,out));
-        if (verbose) $display("Fetch1: ", fshow(out));
+
+        f12f2.enq(tuple2(posLastSupX2,out));
+        if (verbose) $display("Fetch1: ", fshow(out), " posLastSupX2: %d", posLastSupX2);
     endrule
 
     rule doFetch2;
@@ -545,8 +497,7 @@ module mkFetchStage(FetchStage);
                     // cache line size, so all nbSup+1 insts can be fetched
                     // from boot rom. It won't happen that insts fetched from
                     // boot rom is less than requested.
-                    Bit #(TLog #(SupSize)) nbSup = truncate(nbSupX2 >> 1);
-                    mmio.bootRomReq(phys_pc, nbSup);
+                    mmio.bootRomReq(phys_pc, nbSupX2);
                     access_mmio = True;
                 end
                 default: begin
@@ -586,7 +537,7 @@ module mkFetchStage(FetchStage);
 	  $display ("Fetch2: f2_tof3.enq: nbSupX2 %0d out ", nbSupX2, fshow (out));
        end
     endrule
- 
+
 // Break out of i$
     rule doFetch3;
         let {nbSupX2In, fetch3In} = f22f3.first;
@@ -641,13 +592,13 @@ module mkFetchStage(FetchStage);
         // In case of exception, we still need to process at least inst_data[0]
         // (it will be turned to an exception later), so inst_data[0] must be
         // valid.
-        Vector#(SupSize,Maybe#(Instruction)) inst_d = replicate(tagged Valid (0));
+        Vector#(SupSizeX2,Maybe#(Instruction16)) inst_d = replicate(tagged Valid (0));
         if (drop_f22f3 || parse_f22f3) begin
             f22f3.deq();
             if (!isValid(fetch3In.cause)) begin
                 if(fetch3In.access_mmio) begin
-                    if(verbose) $display("get answer from MMIO %d", fetch3In.pc);
                     inst_d <- mmio.bootRomResp;
+                    if(verbose) $display("get answer from MMIO 0x%0x", fetch3In.pc, " ", fshow(inst_d));
                 end
                 else begin
                     if(verbose) $display("get answer from memory %d", fetch3In.pc);
@@ -672,17 +623,9 @@ module mkFetchStage(FetchStage);
             end
         end
         else if (parse_f22f3) begin
-            // Re-interpret fetched 32b parcels (inst_d) as 16b parcels
-            let { n_x16s, v_x16 } <- fav_inst_d_to_x16s (inst_d);
-            // Cap n_x16s, as otherwise we misattribute the bundle's PC
-            // prediction to a later instruction and erroneously think we
-            // took a branch miss. This condition is hit because the cache
-            // interface uses aligned 32b parcels and thus we can end up with
-            // an extra 16b parcel after the window we want. Note that
-            // nbSupX2In will still include the first 16b parcel even if our PC
-            // is misaligned, but this will be discarded by fav_parse_insts.
-            if (n_x16s > extend(nbSupX2In) + 1)
-                n_x16s = extend(nbSupX2In) + 1;
+            Vector#(SupSizeX2,Instruction16) v_x16;
+            for (Integer i=0; i<valueOf(SupSizeX2); i=i+1) v_x16[i] = fromMaybe(?,inst_d[i]);
+            SupCntX2 n_x16s = min(zeroExtend(nbSupX2In)+1, pack(countIf(isValid,inst_d)));
 
             // Parse v_x16 into 32-bit and 16-bit instructions
             Addr pred_next_pc;
@@ -857,8 +800,8 @@ module mkFetchStage(FetchStage);
 			// rs1 is invalid, i.e., not link: push
 			ras.ras[i].popPush(False, Valid (push_addr));
 		     end
-                     else if (dInst.iType == Jr) begin // jalr 
-			if (!dst_link && src1_link) begin  
+                     else if (dInst.iType == Jr) begin // jalr
+			if (!dst_link && src1_link) begin
 			   // rd is link while rs1 is not: pop
 			   nextPc = Valid (pop_addr);
 			   ras.ras[i].popPush(True, Invalid);
@@ -1120,4 +1063,3 @@ module mkFetchStage(FetchStage);
 `endif
     endinterface
 endmodule
- 

--- a/src_Core/RISCY_OOO/procs/lib/Fifos.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Fifos.bsv
@@ -147,7 +147,7 @@ endinstance
 //   endfunction
 // endinstance
 
-module mkSupFifo(SupFifo#(k,n,t)) provisos (
+module mkUGSupFifo(SupFifo#(k,n,t)) provisos (
     Bits#(t,tSz),
     FShow#(t),
     Add#(TExp#(TLog#(k)), 0, k) // k must be power of 2
@@ -164,7 +164,7 @@ module mkSupFifo(SupFifo#(k,n,t)) provisos (
         Bool can_enq = internalFifos[fifoIdx].notFull;
         return (interface SupFifoEnq;
             method Bool canEnq = can_enq;
-            method Action enq(t x) if(can_enq);
+            method Action enq(t x);
                 enqueueElement[i][0] <= tagged Valid x;
             endmethod
         endinterface);
@@ -175,10 +175,10 @@ module mkSupFifo(SupFifo#(k,n,t)) provisos (
         Bool can_deq = internalFifos[fifoIdx].notEmpty;
         return (interface SupFifoDeq;
             method Bool canDeq = can_deq;
-            method t first if(can_deq);
+            method t first;
                 return internalFifos[fifoIdx].first;
             endmethod
-            method Action deq if(can_deq);
+            method Action deq;
                 willDequeue[i][0] <= True;
             endmethod
         endinterface);
@@ -216,6 +216,35 @@ module mkSupFifo(SupFifo#(k,n,t)) provisos (
         function Bool isEmpty(Integer i) = !internalFifos[i].notEmpty;
         return all(isEmpty, indexes);
     endmethod
+endmodule
+
+module mkSupFifo(SupFifo#(k,n,t)) provisos (
+    Bits#(t,tSz),
+    FShow#(t),
+    Add#(TExp#(TLog#(k)), 0, k) // k must be power of 2
+);
+    SupFifo#(k,n,t) ugf <- mkUGSupFifo;
+
+    function SupFifoEnq#(t) getEnqIfc(Integer i);
+        return (interface SupFifoEnq;
+            method Bool canEnq = ugf.enqS[i].canEnq;
+            method Action enq(t x) if(ugf.enqS[i].canEnq) = ugf.enqS[i].enq(x);
+        endinterface);
+    endfunction
+
+    function SupFifoDeq#(t) getDeqIfc(Integer i);
+        return (interface SupFifoDeq;
+            method Bool canDeq = ugf.deqS[i].canDeq;
+            method t first if(ugf.deqS[i].canDeq) = ugf.deqS[i].first;
+            method Action deq if(ugf.deqS[i].canDeq) = ugf.deqS[i].deq;
+        endinterface);
+    endfunction
+
+    Vector#(k,Integer) indexes = genVector;
+    interface Vector enqS = map(getEnqIfc, indexes);
+    interface Vector deqS = map(getDeqIfc, indexes);
+
+    method Bool internalEmpty = ugf.internalEmpty;
 endmodule
 
 

--- a/src_Core/RISCY_OOO/procs/lib/Fifos.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Fifos.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -128,7 +128,7 @@ endinstance
 //   function Get#(Vector#(k,Maybe#(t))) toGet(SupFifo#(k,n, t) f);
 //     return (interface Get;
 //       method ActionValue#(Vector#(k,Maybe#(t)) get;
-// //  
+// //
 //         f.deq;
 //         return f.first;
 //       endmethod
@@ -314,7 +314,7 @@ module mkCFFifo( Fifo#(n, t) ) provisos (Bits#(t,tSz));
 
   method Action deq if( !empty );
     // Tell later stages a dequeue was requested
-    deqReq[0] <= tagged Valid;
+    deqReq[0] <= tagged Valid (?);
   endmethod
 
   method t first if( !empty );
@@ -327,7 +327,7 @@ module mkCFFifo( Fifo#(n, t) ) provisos (Bits#(t,tSz));
     enqReq[1] <= tagged Invalid;
     deqReq[1] <= tagged Invalid;
     // Tell later stages a clear was requested
-    clearReq[0] <= tagged Valid;
+    clearReq[0] <= tagged Valid (?);
   endmethod
 endmodule
 
@@ -649,4 +649,3 @@ module mkCFSCountFifo#(function Bool isFound(t v, st k))(SCountFifo#(n, t, st)) 
     deqEn[1] <= False;
   endmethod
 endmodule
-

--- a/src_Core/RISCY_OOO/procs/lib/IndexedMultiset.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/IndexedMultiset.bsv
@@ -1,0 +1,230 @@
+/*-
+ * Copyright (c) 2020 Jonathan Woodruff
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ *
+ * @BERI_LICENSE_HEADER_START@
+ *
+ * Licensed to BERI Open Systems C.I.C. (BERI) under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  BERI licenses this
+ * file to you under the BERI Hardware-Software License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *   http://www.beri-open-systems.org/legal/license-1-0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, Work distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * @BERI_LICENSE_HEADER_END@
+ */
+
+import Vector::*;
+import Assert::*;
+
+interface IndexedMultisetRemoveIfc#(type idxT);
+    method Action remove(idxT i);
+endinterface
+interface IndexedMultiset#(type idxT, type datT, numeric type remWidth);
+    method ActionValue#(idxT) insert(datT d);
+    // Reserved data values must be the same as the next inserted value or they will be overwritten.
+    method ActionValue#(IndexedMultisetIndices#(idxT)) insertAndReserve(datT ins, datT res);
+    method datT lookup(idxT i);
+    interface Vector#(remWidth, IndexedMultisetRemoveIfc#(idxT)) rPort;
+    method Action clearAll;
+endinterface
+
+typedef struct {
+    datT data;
+    ctr count;
+} IndexedMultisetRecord#(type datT, type ctr) deriving(Bits);
+
+typedef struct {
+    idxT inserted;
+    idxT reserved;
+} IndexedMultisetIndices#(type idxT) deriving(Bits);
+
+typedef struct {
+    idxT idx;
+    datT dat;
+} IndexedMultisetInsert#(type idxT, type datT) deriving(Bits);
+
+module mkIndexedMultiset(IndexedMultiset#(idxT, datT, remWidth))
+    provisos (
+        Bits#(datT, _datsz),
+        Eq#(datT),
+        Bits#(idxT, _idxsz),
+        PrimIndex#(idxT, a__),
+        Alias#(wide_idxT, Bit#(TAdd#(_idxsz,2))) // Allow for generous number of duplicates per data value; 4x index capacity.
+    );
+    Vector#(TExp#(_idxsz), Reg#(IndexedMultisetRecord#(datT,wide_idxT)))
+        records <- replicateM(mkReg(unpack(0)));
+    let recsRead = readVReg(records);
+    RWire#(IndexedMultisetInsert#(idxT,datT)) insertW <- mkRWire;
+    RWire#(IndexedMultisetInsert#(idxT,datT)) reserveW <- mkRWire;
+    Vector#(remWidth, RWire#(idxT)) removeW <- replicateM(mkRWire);
+    PulseWire clearW <- mkPulseWire;
+
+    (* no_implicit_conditions *)
+    rule canon;
+        Vector#(TExp#(_idxsz),IndexedMultisetRecord#(datT,wide_idxT)) recs = readVReg(records);
+        if (insertW.wget matches tagged Valid .r) begin
+            recs[r.idx].data = r.dat;
+            recs[r.idx].count = recs[r.idx].count + 1;
+        end
+        if (reserveW.wget matches tagged Valid .r) recs[r.idx].data = r.dat;
+        for (Integer i = 0; i < valueOf(remWidth); i = i + 1)
+            if (removeW[i].wget matches tagged Valid .r) recs[r].count = recs[r].count - 1;
+        if (clearW) recs = replicate(IndexedMultisetRecord{data: ?, count: 0});
+        writeVReg(records, recs);
+    endrule
+
+    function isEmpty(r) = (r.count == 0);
+    function isFull(r) = (r.count == ~0);
+    function dataMatch(d, r) = (r.data == d);
+    function ActionValue#(idxT) findIdx(datT d, Vector#(TExp#(_idxsz), IndexedMultisetRecord#(datT,wide_idxT)) recs) =
+        actionvalue
+            let mi = findIndex(dataMatch(d),recs);
+            if (!isValid(mi)) mi = findIndex(isEmpty,recs);
+            dynamicAssert(isValid(mi), "failed to insert in indexed multiset");
+            return unpack(pack(validValue(mi)));
+        endactionvalue;
+
+    Vector#(remWidth, IndexedMultisetRemoveIfc#(idxT)) removes;
+    for (Integer i = 0; i < valueOf(remWidth); i = i + 1) begin
+        removes[i] = interface IndexedMultisetRemoveIfc#(idxT);
+            method Action remove(idxT index);
+                dynamicAssert(recsRead[index].count != 0, "removed empty item in indexed multiset");
+                removeW[i].wset(index);
+            endmethod
+        endinterface;
+    end
+
+    Bool anyEmpty = any(isEmpty,recsRead);
+    Bool anyFull = any(isFull,recsRead);
+    method ActionValue#(idxT) insert(datT d) if (anyEmpty && !anyFull);
+        let i <- findIdx(d,recsRead);
+        insertW.wset(IndexedMultisetInsert{idx:i, dat:d});
+        return i;
+    endmethod
+
+    method ActionValue#(IndexedMultisetIndices#(idxT)) insertAndReserve(datT ins, datT res);
+        let insIdx <- findIdx(ins,recsRead);
+        insertW.wset(IndexedMultisetInsert{idx:insIdx, dat:ins});
+        let newRecs = recsRead;
+        newRecs[insIdx].data = ins;
+        let resIdx <- findIdx(res,newRecs);
+        reserveW.wset(IndexedMultisetInsert{idx:resIdx, dat:res});
+        return IndexedMultisetIndices{inserted: insIdx, reserved: resIdx};
+    endmethod
+
+    method datT lookup(idxT i) = records[i].data;
+
+    interface rPort = removes;
+
+    method Action clearAll = clearW.send;
+endmodule
+
+// An implementation of Indexed Multiset that depends on inserting and removing in the same order.
+module mkIndexedMultisetQueue(IndexedMultiset#(Bit#(idxTSz), datT, remWidth))
+    provisos (
+        Alias#(idxT, Bit#(idxTSz)),
+        Bits#(datT, _datsz),
+        Eq#(datT)
+    );
+    Vector#(TExp#(idxTSz), Reg#(datT)) records <- replicateM(mkRegU);
+    Vector#(TExp#(idxTSz), datT) recsRead = readVReg(records);
+
+    Reg#(Bit#(TAdd#(idxTSz,1))) lhead <- mkReg(0);
+    Reg#(Bit#(TAdd#(idxTSz,1))) ltail <- mkReg(0);
+    idxT head = truncate(lhead);
+    Bit#(TAdd#(idxTSz,1)) level = lhead - ltail;
+    //Bool empty = (level==0);
+    Bool full  = (level==fromInteger(valueOf(TExp#(idxTSz))));
+    Bool almostFull = (level>=fromInteger(valueOf(TExp#(idxTSz)))-1);
+
+    RWire#(datT) insertW <- mkRWire;
+    RWire#(datT) reserveW <- mkRWire;
+    Vector#(remWidth, RWire#(idxT)) removeW <- replicateM(mkRWire);
+    PulseWire clearW <- mkPulseWire;
+
+    function Bit#(TAdd#(idxTSz,1)) updateWidePointer(Bit#(TAdd#(idxTSz,1)) lIdx, idxT idx);
+      idxT diff = idx - truncate(lIdx);
+      return lIdx + zeroExtend(diff);
+    endfunction
+    (* no_implicit_conditions *)
+    rule canon;
+        Vector#(TExp#(idxTSz),datT) recs = recsRead;
+        Bit#(TAdd#(idxTSz,1)) nlhead = lhead;
+        Bit#(TAdd#(idxTSz,1)) nltail = ltail;
+        if (insertW.wget matches tagged Valid .d) begin
+            $display("insert dat:%x nlhead:%d", {pack(d),12'b0}, nlhead);
+            idxT i = truncate(nlhead);
+            recs[i] = d;
+            nlhead = nlhead + 1;
+        end
+        if (reserveW.wget matches tagged Valid .d) begin
+            $display("reserve dat:%x nlhead:%d", {pack(d),12'b0}, nlhead);
+            idxT i = truncate(nlhead);
+            recs[i] = d;
+            //nlhead = nlhead + 1;
+        end
+        for (Integer i = 0; i < valueOf(remWidth); i = i + 1)
+            if (removeW[i].wget matches tagged Valid .r) begin
+                $display("remove[%d] idx:%d", i, r);
+                nltail = updateWidePointer(nltail, r);
+            end
+        if (clearW) begin
+            nlhead = 0;
+            nltail = 0;
+        end
+        lhead <= nlhead;
+        ltail <= nltail;
+        writeVReg(records, recs);
+        $display("full:%x ltail:%d lhead:%d level:%d", full, ltail, lhead, level);
+    endrule
+
+    Vector#(remWidth, IndexedMultisetRemoveIfc#(idxT)) removes;
+    for (Integer i = 0; i < valueOf(remWidth); i = i + 1) begin
+        removes[i] = interface IndexedMultisetRemoveIfc#(idxT);
+            method Action remove(idxT idx) = removeW[i].wset(idx);
+        endinterface;
+    end
+
+    method ActionValue#(idxT) insert(datT d) if (!full);
+        Bool next = (recsRead[head-1]!=d);
+        if (next) insertW.wset(d);
+        return (next) ? head:head-1;
+    endmethod
+    // Reserved data values must be the same as the next inserted value or they will be overwritten.
+    method ActionValue#(IndexedMultisetIndices#(idxT)) insertAndReserve(datT ins, datT res) if (!almostFull);
+        idxT insIdx = head - 1; // Default, assuming a match.
+        idxT resIdx = head - 1; // Default, assuming a match.
+        if (recsRead[head - 1]!=ins) begin
+            insIdx = head;
+            insertW.wset(ins); // Increment head.
+            resIdx = head; // new default for reserved.
+            if (res!=ins) begin
+                resIdx = head + 1;
+                reserveW.wset(res); // Increment head again!
+            end
+        end else if (recsRead[head - 1]!=res) begin
+            resIdx = head;
+            reserveW.wset(res);
+        end
+        return IndexedMultisetIndices{inserted: insIdx, reserved: resIdx};
+    endmethod
+
+    method datT lookup(idxT i) = recsRead[i];
+
+    interface rPort = removes;
+
+    method Action clearAll = clearW.send;
+endmodule

--- a/src_Core/RISCY_OOO/procs/lib/IndexedMultiset.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/IndexedMultiset.bsv
@@ -165,22 +165,17 @@ module mkIndexedMultisetQueue(IndexedMultiset#(Bit#(idxTSz), datT, remWidth))
         Bit#(TAdd#(idxTSz,1)) nlhead = lhead;
         Bit#(TAdd#(idxTSz,1)) nltail = ltail;
         if (insertW.wget matches tagged Valid .d) begin
-            $display("insert dat:%x nlhead:%d", {pack(d),12'b0}, nlhead);
             idxT i = truncate(nlhead);
             recs[i] = d;
             nlhead = nlhead + 1;
         end
         if (reserveW.wget matches tagged Valid .d) begin
-            $display("reserve dat:%x nlhead:%d", {pack(d),12'b0}, nlhead);
             idxT i = truncate(nlhead);
             recs[i] = d;
-            //nlhead = nlhead + 1;
         end
         for (Integer i = 0; i < valueOf(remWidth); i = i + 1)
-            if (removeW[i].wget matches tagged Valid .r) begin
-                $display("remove[%d] idx:%d", i, r);
+            if (removeW[i].wget matches tagged Valid .r)
                 nltail = updateWidePointer(nltail, r);
-            end
         if (clearW) begin
             nlhead = 0;
             nltail = 0;
@@ -188,7 +183,6 @@ module mkIndexedMultisetQueue(IndexedMultiset#(Bit#(idxTSz), datT, remWidth))
         lhead <= nlhead;
         ltail <= nltail;
         writeVReg(records, recs);
-        $display("full:%x ltail:%d lhead:%d level:%d", full, ltail, lhead, level);
     endrule
 
     Vector#(remWidth, IndexedMultisetRemoveIfc#(idxT)) removes;
@@ -210,11 +204,10 @@ module mkIndexedMultisetQueue(IndexedMultiset#(Bit#(idxTSz), datT, remWidth))
         if (recsRead[head - 1]!=ins) begin
             insIdx = head;
             insertW.wset(ins); // Increment head.
-            resIdx = head; // new default for reserved.
             if (res!=ins) begin
                 resIdx = head + 1;
                 reserveW.wset(res); // Increment head again!
-            end
+            end else resIdx = head;
         end else if (recsRead[head - 1]!=res) begin
             resIdx = head;
             reserveW.wset(res);

--- a/src_Core/RISCY_OOO/procs/lib/L1CoCache.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/L1CoCache.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -59,6 +59,7 @@ export DCoCache(..);
 export mkDCoCache;
 
 export ISupSz;
+export ISupSzX2;
 export L1ICRqStuck(..);
 export L1IPRqStuck(..);
 export ICoCache(..);
@@ -280,10 +281,11 @@ typedef Bit#(TLog#(ICRqNum)) ICRqMshrIdx;
 typedef Bit#(TLog#(IPRqNum)) IPRqMshrIdx;
 
 typedef SupSize ISupSz;
+typedef TMul#(SupSize, 2) ISupSzX2;
 
 (* synthesize *)
 module mkICRqMshrWrapper(
-    ICRqMshr#(ICRqNum, L1Way, ITag, ProcRqToI, Vector#(ISupSz, Maybe#(Instruction)))
+    ICRqMshr#(ICRqNum, L1Way, ITag, ProcRqToI, Vector#(ISupSzX2, Maybe#(Instruction16)))
 );
     function Addr getAddrFromReq(ProcRqToI r);
         return r.addr;
@@ -347,7 +349,7 @@ typedef IPRqStuck L1IPRqStuck;
 
 
 interface ICoCache;
-    interface Server#(Addr, Vector#(ISupSz, Maybe#(Instruction))) to_proc;
+    interface Server#(Addr, Vector#(ISupSzX2, Maybe#(Instruction16))) to_proc;
     method Action flush;
     method Bool flush_done;
     interface Perf#(L1IPerfType) perf;

--- a/src_Core/RISCY_OOO/procs/lib/MMIOInst.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/MMIOInst.bsv
@@ -77,7 +77,7 @@ module mkMMIOInst(MMIOInst);
 
     method InstFetchTarget getFetchTarget(Addr phyPc);
         let addr = getDataAlignedAddr(phyPc);
-        if (soc_map.m_is_IO_addr (phyPc)) begin
+        if (soc_map.m_is_IO_addr (phyPc, True)) begin
             return IODevice;
         end
         else if(addr >= mainMemBaseAddr && (addr < mainMemBoundAddr) &&

--- a/src_Core/RISCY_OOO/procs/lib/MMIOInst.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/MMIOInst.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2018 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -33,8 +33,8 @@ import MMIOAddrs::*;
 import SoC_Map :: *;    // Bluespec setup
 
 interface MMIOInstToCore;
-    interface FifoDeq#(Tuple2#(Addr, SupWaySel)) instReq;
-    interface FifoEnq#(Vector#(SupSize, Maybe#(Instruction))) instResp;
+    interface FifoDeq#(Tuple2#(Addr, SupWayX2Sel)) instReq;
+    interface FifoEnq#(Vector#(SupSizeX2, Maybe#(Instruction16))) instResp;
     method Action setHtifAddrs(Addr toHost, Addr fromHost);
 endinterface
 
@@ -49,10 +49,10 @@ interface MMIOInst;
     method InstFetchTarget getFetchTarget(Addr phyPc);
     // When req boot rom, need to specify the number of instructions to fetch,
     // i.e., maxWay + 1
-    method Action bootRomReq(Addr phyPc, SupWaySel maxWay);
+    method Action bootRomReq(Addr phyPc, SupWayX2Sel maxWay);
     // The return type is same as I$. An entry is Invalid if it is an access
     // fault or not requested before.
-    method ActionValue#(Vector#(SupSize, Maybe#(Instruction))) bootRomResp;
+    method ActionValue#(Vector#(SupSizeX2, Maybe#(Instruction16))) bootRomResp;
     interface MMIOInstToCore toCore;
 endinterface
 
@@ -66,8 +66,8 @@ module mkMMIOInst(MMIOInst);
     Reg#(DataAlignedAddr) fromHostAddr <- mkConfigReg(0);
     // MMIO requests are handled in a very slow manner at platform, so no need
     // to use large FIFO here
-    Fifo#(1, Tuple2#(Addr, SupWaySel)) reqQ <- mkCFFifo;
-    Fifo#(1, Vector#(SupSize, Maybe#(Instruction))) respQ <- mkCFFifo;
+    Fifo#(1, Tuple2#(Addr, SupWayX2Sel)) reqQ <- mkCFFifo;
+    Fifo#(1, Vector#(SupSizeX2, Maybe#(Instruction16))) respQ <- mkCFFifo;
     // To prevent inst fetch requests from clogging the network, we limit to at
     // most 1 pending req. The resp for the pending req will be buffered in
     // respQ, no affecting other MMIO accesses.
@@ -89,12 +89,12 @@ module mkMMIOInst(MMIOInst);
         end
     endmethod
 
-    method Action bootRomReq(Addr phyPc, SupWaySel maxWay);
+    method Action bootRomReq(Addr phyPc, SupWayX2Sel maxWay);
         reqQ.enq(tuple2(phyPc, maxWay));
         pendQ.enq(?);
     endmethod
 
-    method ActionValue#(Vector#(SupSize, Maybe#(Instruction))) bootRomResp;
+    method ActionValue#(Vector#(SupSizeX2, Maybe#(Instruction16))) bootRomResp;
         pendQ.deq;
         respQ.deq;
         return respQ.first;

--- a/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
@@ -35,6 +35,8 @@ typedef Bit#(TLog#(CoreNum)) CoreId;
 typedef `sizeSup SupSize;
 typedef Bit#(TLog#(SupSize)) SupWaySel;
 typedef Bit#(TLog#(TAdd#(SupSize, 1))) SupCnt;
+typedef TMul#(SupSize, 2) SupSizeX2;
+typedef Bit#(TLog#(SupSizeX2)) SupWayX2Sel;
 
 typedef `NUM_EPOCHS NumEpochs;
 typedef Bit#(TLog#(NumEpochs)) Epoch;
@@ -618,7 +620,7 @@ typedef struct {
 // MMIO
 typedef union tagged {
     // inst fetch: contains the maximum superscaler way to fetch
-    SupWaySel Inst;
+    SupWayX2Sel Inst;
     // data access
     void Ld;
     void St;
@@ -654,7 +656,7 @@ typedef struct {
 typedef union tagged {
     // Resp for INST fetch. A vector entry can be invalid for two reasons: 1)
     // that entry is not requested, 2) that entry is access fault.
-    Vector#(SupSize, Maybe#(Instruction)) InstFetch;
+    Vector#(SupSizeX2, Maybe#(Instruction16)) InstFetch;
     // Resp for DATA access, i.e. LOAD, STORE and AMO
     MMIODataPRs DataAccess;
 } MMIOPRs deriving(Bits, Eq, FShow);

--- a/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -50,7 +50,7 @@ typedef struct {
     Integer validDeqPort;
     Integer validEnqPort;
     Integer validWrongSpecPort;
-    // specBits EHR port assignment  
+    // specBits EHR port assignment
     // correct spec is always the last
     Integer sbDeqPort;
     Integer sbEnqPort;
@@ -85,7 +85,7 @@ module mkSpecFifo#(
     Ehr#(2, idxT) deqP_ehr <- mkEhr(0);
     Reg#(idxT) deqP = deqP_ehr[0]; // port 0 is for deq and canon_deqP
 
-    // make incorrectSpeculation conflict with others 
+    // make incorrectSpeculation conflict with others
     RWire#(void) dummyRWire = (interface RWire;
         method Maybe#(void) wget = Invalid;
         method Action wset(void x) = noAction;

--- a/src_Core/RISCY_OOO/procs/lib/Types.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Types.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -44,9 +44,12 @@ typedef TDiv#(DataSz, 8) NumBytes;
 typedef TLog#(NumBytes) IndxShamt;
 typedef Vector#(NumBytes, Bool) ByteEn;
 
-typedef TDiv#(DataSz, InstSz) DataSzInst;
+typedef TDiv#(DataSz, Inst16_Sz) DataSzInst;
 typedef TLog#(DataSzInst) LgDataSzInst;
 typedef Bit#(LgDataSzInst) DataInstOffset;
+typedef TDiv#(DataSz, Inst16_Sz) MemDataSzInst;
+typedef TLog#(DataSzInst) LgMemDataSzInst;
+typedef Bit#(LgMemDataSzInst) MemDataInstOffset;
 
 // These types show up in many places so they are defined here
 typedef enum {Swap, Add, Xor, And, Or, Min, Max, Minu, Maxu, None} AmoFunc deriving(Bits, Eq, FShow, Bounded);

--- a/src_SSITH_P3/src_BSV/SoC_Map.bsv
+++ b/src_SSITH_P3/src_BSV/SoC_Map.bsv
@@ -133,7 +133,7 @@ interface SoC_Map_IFC;
    method  Bool  m_is_mem_addr (Fabric_Addr addr);
 
    (* always_ready *)
-   method  Bool  m_is_IO_addr (Fabric_Addr addr);
+   method  Bool  m_is_IO_addr (Fabric_Addr addr, Bool imem_not_dmem);
 
    (* always_ready *)
    method  Bool  m_is_near_mem_IO_addr (Fabric_Addr addr);
@@ -286,25 +286,28 @@ module mkSoC_Map (SoC_Map_IFC);
    // Identifies I/O addresses in the Fabric.
    // (Caches needs this information to avoid cacheing these addresses.)
 
-   function Bool fn_is_IO_addr (Fabric_Addr addr);
-      return (   fn_is_plic_addr (addr)
-	      || fn_is_near_mem_io_addr (addr)
-	      || fn_is_flash_mem_addr (addr)
-	      || fn_is_ethernet_0_addr (addr)
-	      || fn_is_dma_0_addr (addr)
-	      || fn_is_uart16550_0_addr  (addr)
-	      || fn_is_gpio_0_addr (addr)
-	      || fn_is_boot_rom_addr (addr)
-	      || fn_is_ddr4_0_uncached_addr (addr)
-	      || fn_is_flash_regs_addr (addr)
-	      || fn_is_uart1_addr (addr)
-	      || fn_is_i2c_addr (addr)
-	      || fn_is_spi_addr (addr)
-	      || fn_is_uart2_addr (addr)
-	      || fn_is_gpio1_addr (addr)
-	      || fn_is_gpio2_addr (addr)
-	      || fn_is_xdma_control (addr)
-	      || fn_is_xdma_ecam (addr)
+   function Bool fn_is_IO_addr (Fabric_Addr addr, Bool imem_not_dmem);
+      return (   fn_is_boot_rom_addr (addr)
+        || fn_is_ddr4_0_uncached_addr (addr)
+        || fn_is_flash_mem_addr (addr)
+        || (   (! imem_not_dmem)
+		  && (   fn_is_plic_addr (addr)
+	        || fn_is_near_mem_io_addr (addr)
+	        || fn_is_ethernet_0_addr (addr)
+	        || fn_is_dma_0_addr (addr)
+	        || fn_is_uart16550_0_addr  (addr)
+	        || fn_is_gpio_0_addr (addr)
+	        || fn_is_flash_regs_addr (addr)
+	        || fn_is_uart1_addr (addr)
+	        || fn_is_i2c_addr (addr)
+	        || fn_is_spi_addr (addr)
+	        || fn_is_uart2_addr (addr)
+	        || fn_is_gpio1_addr (addr)
+	        || fn_is_gpio2_addr (addr)
+	        || fn_is_xdma_control (addr)
+	        || fn_is_xdma_ecam (addr)
+          )
+         )
 	      );
    endfunction
 
@@ -364,7 +367,7 @@ module mkSoC_Map (SoC_Map_IFC);
 
    method  Bool  m_is_mem_addr (Fabric_Addr addr) = fn_is_mem_addr (addr);
 
-   method  Bool  m_is_IO_addr (Fabric_Addr addr) = fn_is_IO_addr (addr);
+   method  Bool  m_is_IO_addr (Fabric_Addr addr, Bool imem_not_dmem) = fn_is_IO_addr (addr, imem_not_dmem);
 
    method  Bool  m_is_near_mem_IO_addr (Fabric_Addr addr) = fn_is_near_mem_io_addr (addr);
 

--- a/src_Testbench/SoC/SoC_Map.bsv
+++ b/src_Testbench/SoC/SoC_Map.bsv
@@ -104,7 +104,7 @@ interface SoC_Map_IFC;
    method  Bool  m_is_mem_addr (Fabric_Addr addr);
 
    (* always_ready *)
-   method  Bool  m_is_IO_addr (Fabric_Addr addr);
+   method  Bool  m_is_IO_addr (Fabric_Addr addr, Bool imem_not_dmem);
 
    (* always_ready *)
    method  Bool  m_is_near_mem_IO_addr (Fabric_Addr addr);
@@ -212,11 +212,14 @@ module mkSoC_Map (SoC_Map_IFC);
    // Identifies I/O addresses in the Fabric.
    // (Caches need this information to avoid cacheing these addresses.)
 
-   function Bool fn_is_IO_addr (Fabric_Addr addr);
+   function Bool fn_is_IO_addr (Fabric_Addr addr, Bool imem_not_dmem);
       return (   fn_is_boot_rom_addr (addr)
-	      || fn_is_near_mem_io_addr (addr)
-	      || fn_is_plic_addr (addr)
-	      || fn_is_uart0_addr  (addr)
+        || (   (! imem_not_dmem)
+	    && (   fn_is_near_mem_io_addr (addr)
+	        || fn_is_plic_addr (addr)
+	        || fn_is_uart0_addr  (addr)
+         )
+      )
 	      );
    endfunction
 
@@ -256,7 +259,7 @@ module mkSoC_Map (SoC_Map_IFC);
 
    method  Bool  m_is_mem_addr (Fabric_Addr addr) = fn_is_mem_addr (addr);
 
-   method  Bool  m_is_IO_addr (Fabric_Addr addr) = fn_is_IO_addr (addr);
+   method  Bool  m_is_IO_addr (Fabric_Addr addr, Bool imem_not_dmem) = fn_is_IO_addr (addr, imem_not_dmem);
 
    method  Bool  m_is_near_mem_IO_addr (Fabric_Addr addr) = fn_is_near_mem_io_addr (addr);
 


### PR DESCRIPTION
This is a refactor of instruction fetch to be cleaner and simpler.  This has been tested running FreeBSD and does not regress performance.

1. Instruction fetch memory (both ICache and MMIO) now support instruction fragment aligned accesses directly to remove complexity around fixing this up in the Fetch pipeline.
2. The instruction fetch pipeline now uses a SupFifo to support instruction picking with a much simpler algorithm.  That is, at the end of Fetch3, instruction fragments are enqueud to a SupFifo, up to 2xSupWidth per cycle.  The beginning of decode picks up to SupWidth instructions from these fragments, and any unpicked fragments simply fall to the head for the next cycle to pick.
3. To reduce the overhead of the SupFifo, which contains both a PC and PredPC for each fragment, a table is used to hold upper bits of PCs in flight in the instruction fetch pipeline, with indices and offsets handled in the pipeline itself.