### PR TITLE
Speculation Pruning

### DIFF
--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -624,7 +624,7 @@ module mkFetchStage(FetchStage);
                         end
                      end else if (!isValid(nextPc)) begin
                         // A Jr will jump; if we don't have a record, we should wait to prevent wasted work.
-                        nextPc = Valid (-1); // Dummy value to prevent progress.
+                        nextPc = Valid (0); // Dummy value to prevent progress.
                      end
                   end
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -545,8 +545,8 @@ module mkFetchStage(FetchStage);
       for (Integer i = 0; i < valueof(SupSize); i=i+1) begin
          if (decodeIn[i] matches tagged Valid .in)  begin
             let cause = in.cause;
-            CapMem pc = decompressPc(in.pc);
-            CapMem ppc = decompressPc(in.ppc);
+            Addr pc = decompressPc(in.pc);
+            Addr ppc = decompressPc(in.ppc);
             pcBlocks.rPort[i].remove(in.pc.idx);
             if (verbose)
                $display("Decode: %0d in = ", i, fshow (in));
@@ -634,7 +634,7 @@ module mkFetchStage(FetchStage);
                   // If we don't have a good guess about where we are going, don't proceed.
                   if ((!isValid(nextPc)) && (!in.pred_jump)) begin
                      // Invalid virtual address to ensure redirection.
-                     ppc = setAddrUnsafe(nullCap, {2'b01,?});
+                     ppc = {2'b01,?};
                      decode_epoch_local = !decode_epoch_local;
                   // check previous mispred
                   end if (nextPc matches tagged Valid .decode_pred_next_pc &&& (decode_pred_next_pc != ppc)) begin

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -624,7 +624,7 @@ module mkFetchStage(FetchStage);
                         end
                      end else if (!isValid(nextPc)) begin
                         // A Jr will jump; if we don't have a record, we should wait to prevent wasted work.
-                        nextPc = Valid (0); // Dummy value to prevent progress.
+                        nextPc = Valid ({2'b01,?}); // Invalid virtual address to prevent progress.
                      end
                   end
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -346,7 +346,7 @@ module mkFetchStage(FetchStage);
     // there is no FIFO between doFetch1 and TLB, when OOO commit stage wait
     // TLB idle to change VM CSR / signal flush TLB, there is no wrong path
     // request afterwards to race with the system code that manage paget table.
-    rule doFetch1(started && !(waitForRedirect[0]) && !(waitForFlush[0]));
+    rule doFetch1(started && !waitForRedirect[0] && !waitForFlush[0]);
         let pc = pc_reg[pc_fetch1_port];
 
         // Grab a chain of predictions from the BTB, which predicts targets for the next
@@ -622,6 +622,9 @@ module mkFetchStage(FetchStage);
                            // same reg: push
                            ras.ras[i].popPush(False, Valid (push_addr));
                         end
+                     end else if (!isValid(nextPc)) begin
+                        // A Jr will jump; if we don't have a record, we should wait to prevent wasted work.
+                        nextPc = Valid (-1); // Dummy value to prevent progress.
                      end
                   end
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -624,7 +624,7 @@ module mkFetchStage(FetchStage);
                         end
                      end else if (!isValid(nextPc)) begin
                         // A Jr will jump; if we don't have a record, we should wait to prevent wasted work.
-                        nextPc = Valid ({2'b01,?}); // Invalid virtual address to prevent progress.
+                        nextPc = Valid (setAddrUnsafe(nullCap,{2'b01,?})); // Invalid virtual address to prevent progress.
                      end
                   end
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -155,6 +155,7 @@ typedef struct {
 typedef struct {
   PcCompressed pc;
   PcCompressed ppc;
+  Bool pred_jump;
   Bool decode_epoch;
   Epoch main_epoch;
   Instruction inst;
@@ -172,6 +173,7 @@ function InstrFromFetch3 fetch3_2_instC(Fetch3ToDecode in, Instruction inst, Bit
       ppc: fromMaybe(PcCompressed{lsb: in.pc.lsb + 2,
                                   idx: in.pc.idx + ((in.pc.lsb == -2) ? 1:0)}, // If we move to a new page, we will move to the next index in the compressed PC table.
                      in.ppc),
+      pred_jump: isValid(in.ppc),
       decode_epoch: in.decode_epoch,
       main_epoch: in.main_epoch,
       inst: inst,
@@ -543,8 +545,8 @@ module mkFetchStage(FetchStage);
       for (Integer i = 0; i < valueof(SupSize); i=i+1) begin
          if (decodeIn[i] matches tagged Valid .in)  begin
             let cause = in.cause;
-            let pc = decompressPc(in.pc);
-            let ppc = decompressPc(in.ppc);
+            CapMem pc = decompressPc(in.pc);
+            CapMem ppc = decompressPc(in.ppc);
             pcBlocks.rPort[i].remove(in.pc.idx);
             if (verbose)
                $display("Decode: %0d in = ", i, fshow (in));
@@ -622,19 +624,20 @@ module mkFetchStage(FetchStage);
                            // same reg: push
                            ras.ras[i].popPush(False, Valid (push_addr));
                         end
-                     end else if (!isValid(nextPc)) begin
-                        // A Jr will jump; if we don't have a record, we should wait to prevent wasted work.
-                        nextPc = Valid (setAddrUnsafe(nullCap,{2'b01,?})); // Invalid virtual address to prevent progress.
                      end
                   end
-
                   if(verbose) begin
                      $display("Branch prediction: ", fshow(dInst.iType), " ; ", fshow(pc), " ; ",
                               fshow(ppc), " ; ", fshow(pred_taken), " ; ", fshow(nextPc));
                   end
 
+                  // If we don't have a good guess about where we are going, don't proceed.
+                  if ((!isValid(nextPc)) && (!in.pred_jump)) begin
+                     // Invalid virtual address to ensure redirection.
+                     ppc = setAddrUnsafe(nullCap, {2'b01,?});
+                     decode_epoch_local = !decode_epoch_local;
                   // check previous mispred
-                  if (nextPc matches tagged Valid .decode_pred_next_pc &&& (decode_pred_next_pc != ppc)) begin
+                  end if (nextPc matches tagged Valid .decode_pred_next_pc &&& (decode_pred_next_pc != ppc)) begin
                      if (verbose) $display("%x: ppc and decodeppc :  %h %h", pc, ppc, decode_pred_next_pc);
                      decode_epoch_local = !decode_epoch_local;
                      redirectPc = Valid (decode_pred_next_pc); // record redirect next pc

--- a/src_Core/RISCY_OOO/procs/lib/DTlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DTlb.bsv
@@ -466,9 +466,9 @@ module mkDTlb#(
             let trans_result = tlb.translate(vpn, vm_info.asid);
             if (!validVirtualAddress(r.addr)) begin
                 // page fault
-                Exception fault = r.write ? excStorePageFault : excLoadPageFault;
+                Exception fault = r.write ? StorePageFault : LoadPageFault;
                 pendWait[idx] <= None;
-                pendResp[idx] <= tuple3(?, Valid (fault), False);
+                pendResp[idx] <= tuple2(?, Valid (fault));
                 if(verbose) $display("[DTLB] req invalid virtual address: idx %d; ", idx, fshow(r));
             end else if (trans_result.hit) begin
                 // TLB hit

--- a/src_Core/RISCY_OOO/procs/lib/DTlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DTlb.bsv
@@ -464,7 +464,13 @@ module mkDTlb#(
         else if (vm_info.sv39) begin
             let vpn = getVpn(r.addr);
             let trans_result = tlb.translate(vpn, vm_info.asid);
-            if (trans_result.hit) begin
+            if (!validVirtualAddress(r.addr)) begin
+                // page fault
+                Exception fault = r.write ? excStorePageFault : excLoadPageFault;
+                pendWait[idx] <= None;
+                pendResp[idx] <= tuple3(?, Valid (fault), False);
+                if(verbose) $display("[DTLB] req invalid virtual address: idx %d; ", idx, fshow(r));
+            end else if (trans_result.hit) begin
                 // TLB hit
                 let entry = trans_result.entry;
                 // check permission

--- a/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
@@ -300,7 +300,8 @@ module mkITlb(ITlb::ITlb);
                 else if (vm_info.sv39) begin
                     let vpn = getVpn(vaddr);
                     let trans_result = tlb.translate(vpn, vm_info.asid);
-                    if (trans_result.hit) begin
+                    if (!validVirtualAddress(vaddr)) hitQ.enq(tuple3(?, Valid (excInstPageFault), False));
+                    else if (trans_result.hit) begin
                         // TLB hit
                         let entry = trans_result.entry;
                         // check permission

--- a/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
@@ -300,7 +300,7 @@ module mkITlb(ITlb::ITlb);
                 else if (vm_info.sv39) begin
                     let vpn = getVpn(vaddr);
                     let trans_result = tlb.translate(vpn, vm_info.asid);
-                    if (!validVirtualAddress(vaddr)) hitQ.enq(tuple3(?, Valid (excInstPageFault), False));
+                    if (!validVirtualAddress(vaddr)) hitQ.enq(tuple2(?, Valid (InstPageFault)));
                     else if (trans_result.hit) begin
                         // TLB hit
                         let entry = trans_result.entry;

--- a/src_Core/RISCY_OOO/procs/lib/TlbTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TlbTypes.bsv
@@ -88,7 +88,7 @@ function Vpn getVpn(Addr addr) = addr[38:12];
 function PageOffset getPageOffset(Addr addr) = truncate(addr);
 
 // All the upper bits should be equal for a valid SV39 virtual address.
-function Bool validVirtualAddress(Addr addr) = ((^addr[63:39]) == 0);
+function Bool validVirtualAddress(Addr addr) = ((addr[63:39] ^ {addr[39],addr[63:40]}) == 0);
 
 function Addr getPTBaseAddr(Ppn basePpn);
     PageOffset offset = 0;

--- a/src_Core/RISCY_OOO/procs/lib/TlbTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TlbTypes.bsv
@@ -88,7 +88,7 @@ function Vpn getVpn(Addr addr) = addr[38:12];
 function PageOffset getPageOffset(Addr addr) = truncate(addr);
 
 // All the upper bits should be equal for a valid SV39 virtual address.
-function Bool validVirtualAddress(Addr addr) = ((addr[63:39] ^ {addr[39],addr[63:40]}) == 0);
+function Bool validVirtualAddress(Addr addr) =  (addr[63:39] == {addr[39],addr[63:40]});
 
 function Addr getPTBaseAddr(Ppn basePpn);
     PageOffset offset = 0;

--- a/src_Core/RISCY_OOO/procs/lib/TlbTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TlbTypes.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -49,7 +49,7 @@ typedef 44 PpnSz;
 typedef Bit#(PpnSz) Ppn;
 typedef 12 PageOffsetSz; // 4KB basic page
 typedef Bit#(PageOffsetSz) PageOffset;
-typedef 9 VpnIdxSz; // Vpn is broken down to 3 indexes to 3 levels of page table 
+typedef 9 VpnIdxSz; // Vpn is broken down to 3 indexes to 3 levels of page table
 typedef Bit#(VpnIdxSz) VpnIdx;
 typedef Bit#(2) PageWalkLevel; // 2: 1GB page, 1: 2MB page, 0: 4KB page
 typedef 3 NumPageWalkLevels;
@@ -86,6 +86,9 @@ typedef struct {
 function Vpn getVpn(Addr addr) = addr[38:12];
 
 function PageOffset getPageOffset(Addr addr) = truncate(addr);
+
+// All the upper bits should be equal for a valid SV39 virtual address.
+function Bool validVirtualAddress(Addr addr) = ((^addr[63:39]) == 0);
 
 function Addr getPTBaseAddr(Ppn basePpn);
     PageOffset offset = 0;


### PR DESCRIPTION
This set of changes prevents speculation in 3 places to reduce DRAM traffic (~13% across our MiBench benchmarks).
The first is to prevent instructions that jump to a register target and do not have a prediction from the BTB from speculating the default prediction (straight through).  Instead, we flush the fetch pipeline and wait for redirection.
The second and third are by not performing a page table walk for invalid virtual addresses in the instruction and data TLBs.  Previously, even if the upper bits of a pointer did not constitute a valid virtual address, the would-be virtual page number was still fed into the page walker and a page table walk was done on them.  We now check that the upper bits are a valid sign extension, and fail early if not, preventing a table walk.