### PR TITLE
scheduling and timing

### DIFF
--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -1,7 +1,7 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
 // Portions Copyright (c) 2019-2020 Bluespec, Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -9,10 +9,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -193,6 +193,7 @@ interface CoreFixPoint;
     interface MemExePipeline memExeIfc;
     method Action killAll; // kill everything: used by commit stage
     interface Reg#(Bool) doStatsIfc;
+    method Bool pendingIncorrectSpec;
 endinterface
 
 typedef enum {
@@ -314,7 +315,7 @@ module mkCore#(CoreId coreId)(Core);
         );
 
         // whether perf data is collected
-        Reg#(Bool) doStatsReg <- mkConfigReg(False); 
+        Reg#(Bool) doStatsReg <- mkConfigReg(False);
 
         // write aggressive elements + wakupe reservation stations
         function Action writeAggr(Integer wrAggrPort, PhyRIndx dst);
@@ -370,14 +371,14 @@ module mkCore#(CoreId coreId)(Core);
                 method setRegReadyAggr = writeAggr(aluWrAggrPort(i));
                 interface sendBypass = sendBypassIfc;
                 method writeRegFile = writeCons(aluWrConsPort(i));
-                method Action redirect(Addr new_pc, SpecTag spec_tag, InstTag inst_tag);
+                method Action redirect(Addr new_pc, SpecTag spec_tag, InstTag inst_tag, SpecBits spec_bits);
                     if (verbose) begin
                         $display("[ALU redirect - %d] ", i, fshow(new_pc),
                                  "; ", fshow(spec_tag), "; ", fshow(inst_tag));
                     end
                     epochManager.incrementEpoch;
                     fetchStage.redirect(new_pc);
-                    globalSpecUpdate.incorrectSpec(False, spec_tag, inst_tag);
+                    globalSpecUpdate.incorrectSpec(False, spec_tag, inst_tag, spec_bits);
                 endmethod
                 method correctSpec = globalSpecUpdate.correctSpec[finishAluCorrectSpecPort(i)].put;
                 method doStats = doStatsReg._read;
@@ -438,9 +439,10 @@ module mkCore#(CoreId coreId)(Core);
         interface fpuMulDivExeIfc = fpuMulDivExe;
         interface memExeIfc = memExe;
         method Action killAll;
-            globalSpecUpdate.incorrectSpec(True, ?, ?);
+            globalSpecUpdate.incorrectSpec(True, ?, ?, 0);
         endmethod
         interface doStatsIfc = doStatsReg;
+        method pendingIncorrectSpec = globalSpecUpdate.pendingIncorrectSpec;
     endmodule
     CoreFixPoint coreFix <- moduleFix(mkCoreFixPoint);
 
@@ -575,6 +577,7 @@ module mkCore#(CoreId coreId)(Core);
         method stbEmpty = stb.isEmpty;
         method stqEmpty = lsq.stqEmpty;
         method lsqSetAtCommit = lsq.setAtCommit;
+        method pauseCommit = coreFix.pendingIncorrectSpec;
         method tlbNoPendingReq = iTlb.noPendingReq && dTlb.noPendingReq;
 
         method setFlushTlbs;

--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -380,6 +380,7 @@ module mkCore#(CoreId coreId)(Core);
                     fetchStage.redirect(new_pc);
                     globalSpecUpdate.incorrectSpec(False, spec_tag, inst_tag, spec_bits);
                 endmethod
+                method Bool pauseExecute = globalSpecUpdate.pendingIncorrectSpec;
                 method correctSpec = globalSpecUpdate.correctSpec[finishAluCorrectSpecPort(i)].put;
                 method doStats = doStatsReg._read;
             endinterface);

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -154,6 +154,7 @@ interface AluExeInput;
     method Action writeRegFile(PhyRIndx dst, Data data);
     // redirect
     method Action redirect(Addr new_pc, SpecTag spec_tag, InstTag inst_tag, SpecBits spec_bits);
+    method Bool pauseExecute;
     // spec update
     method Action correctSpec(SpecTag t);
 
@@ -262,7 +263,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
         });
     endrule
 
-    rule doExeAlu;
+    rule doExeAlu(!inIfc.pauseExecute);
         regToExeQ.deq;
         let regToExe = regToExeQ.first;
         let x = regToExe.data;
@@ -305,7 +306,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
         });
     endrule
 
-    rule doFinishAlu;
+    rule doFinishAlu(!inIfc.pauseExecute);
         exeToFinQ.deq;
         let exeToFin = exeToFinQ.first;
         let x = exeToFin.data;

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -153,7 +153,7 @@ interface AluExeInput;
     // write reg file & set conservative sb
     method Action writeRegFile(PhyRIndx dst, Data data);
     // redirect
-    method Action redirect(Addr new_pc, SpecTag spec_tag, InstTag inst_tag);
+    method Action redirect(Addr new_pc, SpecTag spec_tag, InstTag inst_tag, SpecBits spec_bits);
     // spec update
     method Action correctSpec(SpecTag t);
 
@@ -201,7 +201,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
         if(x.regs.dst matches tagged Valid .dst) begin
             inIfc.setRegReadyAggr(dst.indx);
         end
-        
+
         // go to next stage
         dispToRegQ.enq(ToSpecFifo {
             data: AluDispatchToRegRead {
@@ -330,7 +330,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
         if (x.controlFlow.mispredict) (* nosplit *) begin
             // wrong branch predictin, we must have spec tag
             doAssert(isValid(x.spec_tag), "mispredicted branch must have spec tag");
-            inIfc.redirect(x.controlFlow.nextPc, validValue(x.spec_tag), x.tag);
+            inIfc.redirect(x.controlFlow.nextPc, validValue(x.spec_tag), x.tag, exeToFin.spec_bits);
             // must be a branch, train branch predictor
             doAssert(x.iType == Jr || x.iType == Br, "only jr and br can mispredict");
             inIfc.fetch_train_predictors(FetchTrainBP {
@@ -342,6 +342,8 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
                 mispred: True,
                 isCompressed: x.isCompressed
             });
+            $display("alu mispredict pc¤: %x, nextPc: %x, %d",
+                     x.controlFlow.pc, x.controlFlow.nextPc, cur_cycle);
 `ifdef PERF_COUNT
             // performance counter
             if(inIfc.doStats) begin
@@ -358,7 +360,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
             if (x.spec_tag matches tagged Valid .valid_spec_tag) begin
                 inIfc.correctSpec(valid_spec_tag);
             end
-            // train branch predictor if needed 
+            // train branch predictor if needed
             // since we can only do 1 training in a cycle, split the rule
             // XXX not training JAL, reduce chance of conflicts
             if(x.iType == Jr || x.iType == Br) begin
@@ -397,4 +399,3 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
         endcase);
     endmethod
 endmodule
-

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -263,7 +263,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
         });
     endrule
 
-    rule doExeAlu(!inIfc.pauseExecute);
+    rule doExeAlu;
         regToExeQ.deq;
         let regToExe = regToExeQ.first;
         let x = regToExe.data;

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -343,8 +343,8 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
                 mispred: True,
                 isCompressed: x.isCompressed
             });
-            $display("alu mispredict pc¤: %x, nextPc: %x, %d",
-                     x.controlFlow.pc, x.controlFlow.nextPc, cur_cycle);
+            if(verbose) $display("alu mispredict pc¤: %x, nextPc: %x, %d",
+                                  x.controlFlow.pc, x.controlFlow.nextPc, cur_cycle);
 `ifdef PERF_COUNT
             // performance counter
             if(inIfc.doStats) begin

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/CommitStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/CommitStage.bsv
@@ -939,11 +939,11 @@ module mkCommitStage#(CommitInput inIfc)(CommitStage);
                     stop = True;
                 end
                 else begin
-                    if (verbose) $display("[doCommitNormalInst - %d] ", i, fshow(inst_tag), " ; ", fshow(x));
+                    if (verbose) $display("[doCommitNormalInst - %d] ", i, fshow(inst_tag), " ; ", fshow(x), cur_cycle);
 
 		    if (verbosity >= 1) begin
 		       $display("instret:%0d  PC:0x%0h  instr:0x%08h", rg_serial_num + instret, x.pc, x.orig_inst,
-				"   iType:", fshow (x.iType), "    [doCommitNormalInst [%0d]]", i);
+				"   iType:", fshow (x.iType), "    [doCommitNormalInst [%0d]]", i, cur_cycle);
 		    end
 
 `ifdef INCLUDE_TANDEM_VERIF

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -543,7 +543,7 @@ module mkFetchStage(FetchStage);
       for (Integer i = 0; i < valueof(SupSize); i=i+1) begin
          Addr pc = decompressPc(validValue(decodeIn[i]).pc);
          Addr ppc = decompressPc(validValue(decodeIn[i]).ppc);
-         let decode_result = decode(validValue(decodeIn[i]).inst, getFlags(pc)==1); // Decode 32b inst, or 32b expansion of 16b inst
+         let decode_result = decode(validValue(decodeIn[i]).inst); // Decode 32b inst, or 32b expansion of 16b inst
          let dInst = decode_result.dInst;
          let regs = decode_result.regs;
          DirPredResult#(DirPredTrainInfo) dir_pred = DirPredResult{taken: False, train: ?};
@@ -551,7 +551,7 @@ module mkFetchStage(FetchStage);
             dir_pred <- dirPred.pred[i].pred;
             likely_epoch_change = (dir_pred.taken != validValue(decodeIn[i]).pred_jump);
          end
-         Maybe#(CapMem) dir_ppc = decodeBrPred(pc, decode_result.dInst, dir_pred.taken, (validValue(decodeIn[i]).inst_kind == Inst_32b));
+         Maybe#(Addr) dir_ppc = decodeBrPred(pc, decode_result.dInst, dir_pred.taken, (validValue(decodeIn[i]).inst_kind == Inst_32b));
          if (decodeIn[i] matches tagged Valid .in)  begin
             let cause = in.cause;
             pcBlocks.rPort[i].remove(in.pc.idx);
@@ -585,7 +585,7 @@ module mkFetchStage(FetchStage);
                // update predicted next pc
                if (!isValid(cause)) begin
                   // direction predict
-                  Maybe#(CapMem) nextPc = dir_ppc;
+                  Maybe#(Addr) nextPc = dir_ppc;
                   // return address stack link reg is x1 or x5
                   function Bool linkedR(Maybe#(ArchRIndx) register);
                      Bool res = False;

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -630,6 +630,12 @@ module mkFetchStage(FetchStage);
                            // same reg: push
                            ras.ras[i].popPush(False, Valid (push_addr));
                         end
+<<<<<<< HEAD
+=======
+                     end else if (!isValid(nextPc)) begin
+                        // A Jr will jump; if we don't have a record, we should wait to prevent wasted work.
+                        nextPc = Valid (setAddrUnsafe(nullCap,{2'b01,?})); // Invalid virtual address to prevent progress.
+>>>>>>> 1b5a036c... Two fixes: do a proper "all bits are the same" function, as well as
                      end
                   end
                   if(verbose) begin

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -431,7 +431,7 @@ module mkFetchStage(FetchStage);
        end
     endrule
 
-// Break out of i$
+    // Break out of i$
     Vector#(SupSizeX2,Integer) indexes = genVector;
     function Bool f32d_lane_notFull(Integer i) = f32d.enqS[i].canEnq;
     rule doFetch3(all(f32d_lane_notFull, indexes));
@@ -539,12 +539,21 @@ module mkFetchStage(FetchStage);
       // Note that only 1 redirection may happen in a cycle
       Maybe#(IType) redirectInst = Invalid;
 `endif
-
+      Bool likely_epoch_change = False;
       for (Integer i = 0; i < valueof(SupSize); i=i+1) begin
+         Addr pc = decompressPc(validValue(decodeIn[i]).pc);
+         Addr ppc = decompressPc(validValue(decodeIn[i]).ppc);
+         let decode_result = decode(validValue(decodeIn[i]).inst, getFlags(pc)==1); // Decode 32b inst, or 32b expansion of 16b inst
+         let dInst = decode_result.dInst;
+         let regs = decode_result.regs;
+         DirPredResult#(DirPredTrainInfo) dir_pred = DirPredResult{taken: False, train: ?};
+         if(decode_result.dInst.iType == Br && !likely_epoch_change) begin
+            dir_pred <- dirPred.pred[i].pred;
+            likely_epoch_change = (dir_pred.taken != validValue(decodeIn[i]).pred_jump);
+         end
+         Maybe#(CapMem) dir_ppc = decodeBrPred(pc, decode_result.dInst, dir_pred.taken, (validValue(decodeIn[i]).inst_kind == Inst_32b));
          if (decodeIn[i] matches tagged Valid .in)  begin
             let cause = in.cause;
-            let pc = decompressPc(in.pc);
-            let ppc = decompressPc(in.ppc);
             pcBlocks.rPort[i].remove(in.pc.idx);
             if (verbose)
                $display("Decode: %0d in = ", i, fshow (in));
@@ -576,14 +585,7 @@ module mkFetchStage(FetchStage);
                // update predicted next pc
                if (!isValid(cause)) begin
                   // direction predict
-                  Bool pred_taken = False;
-                  if(dInst.iType == Br) begin
-                     let pred_res <- dirPred.pred[i].pred(pc);
-                     pred_taken = pred_res.taken;
-                     dp_train = pred_res.train;
-                  end
-                  Maybe#(Addr) nextPc = decodeBrPred(pc, dInst, pred_taken, (in.inst_kind == Inst_32b));
-
+                  Maybe#(CapMem) nextPc = dir_ppc;
                   // return address stack link reg is x1 or x5
                   function Bool linkedR(Maybe#(ArchRIndx) register);
                      Bool res = False;
@@ -649,7 +651,7 @@ module mkFetchStage(FetchStage);
                let out = FromFetchStage{pc: pc,
                                         ppc: ppc,
                                         main_epoch: in.main_epoch,
-                                        dpTrain: dp_train,
+                                        dpTrain: dir_pred.train,
                                         inst: in.inst,
                                         dInst: dInst,
                                         orig_inst: in.orig_inst,

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -630,12 +630,6 @@ module mkFetchStage(FetchStage);
                            // same reg: push
                            ras.ras[i].popPush(False, Valid (push_addr));
                         end
-<<<<<<< HEAD
-=======
-                     end else if (!isValid(nextPc)) begin
-                        // A Jr will jump; if we don't have a record, we should wait to prevent wasted work.
-                        nextPc = Valid (setAddrUnsafe(nullCap,{2'b01,?})); // Invalid virtual address to prevent progress.
->>>>>>> 1b5a036c... Two fixes: do a proper "all bits are the same" function, as well as
                      end
                   end
                   if(verbose) begin

--- a/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
@@ -50,18 +50,22 @@ endfunction
 
 // general types for direction predictor
 
+// Function to offset PC by the probable size of an instruction without a full add delay.
+function Addr offsetPc(Addr pc, Integer i) = {truncateLSB(pc), pc[7:0] + (fromInteger(i)*4)};
+
 typedef struct {
     Bool taken;
     trainInfoT train; // info that a branch must keep for future training
 } DirPredResult#(type trainInfoT) deriving(Bits, Eq, FShow);
 
 interface DirPred#(type trainInfoT);
-    method ActionValue#(DirPredResult#(trainInfoT)) pred(Addr pc);
+    method ActionValue#(DirPredResult#(trainInfoT)) pred;
 endinterface
 
 interface DirPredictor#(type trainInfoT);
+    method Action nextPc(Addr nextPc);
     interface Vector#(SupSize, DirPred#(trainInfoT)) pred;
-    method Action update(Addr pc, Bool taken, trainInfoT train, Bool mispred);
+    method Action update(Bool taken, trainInfoT train, Bool mispred);
     method Action flush;
     method Bool flush_done;
 endinterface

--- a/src_Core/RISCY_OOO/procs/lib/Btb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Btb.bsv
@@ -116,7 +116,10 @@ module mkBtbCore(NextAddrPred#(hashSz))
         // Start SupSizeX2 BTB lookups, but ensure to lookup in the appropriate
         // bank for the alignment of each potential branch.
         for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1) begin
-            BtbAddr a = unpack(pack(getBtbAddr(pc)) + fromInteger(i));
+            // Only add lower bits for timing.
+            BtbAddr a = getBtbAddr(pc);
+            a = unpack({a.tag, {a.index,a.bank} + fromInteger(i)});
+            //BtbAddr a = unpack(pack(getBtbAddr(pc)) + fromInteger(i));
             fullRecords[a.bank].lookupStart(MapKeyIndex{key: hash(a.tag), index: a.index});
             compressedRecords[a.bank].lookupStart(MapKeyIndex{key: hash(a.tag), index: a.index});
         end

--- a/src_Core/RISCY_OOO/procs/lib/Btb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Btb.bsv
@@ -109,7 +109,8 @@ module mkBtbCore(NextAddrPred#(hashSz))
         // Start SupSizeX2 BTB lookups, but ensure to lookup in the appropriate
         // bank for the alignment of each potential branch.
         for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1) begin
-            BtbAddr a = unpack(pack(addr) + fromInteger(i));
+            BtbAddr a = unpack(pack(addr));
+            a = unpack({a.tag, {a.index,a.bank} + fromInteger(i)});
             records[a.bank].lookupStart(MapKeyIndex{key: hash(a.tag), index: a.index});
         end
     endmethod

--- a/src_Core/RISCY_OOO/procs/lib/Btb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Btb.bsv
@@ -86,7 +86,7 @@ module mkBtbCore(NextAddrPred#(hashSz))
         fullRecords <- replicateM(mkMapLossyBRAM);
     Vector#(SupSizeX2, MapSplit#(HashedTag#(hashSz), BtbIndex, VnD#(CompressedTarget), BtbAssociativity))
         compressedRecords <- replicateM(mkMapLossyBRAM);
-    RWire#(BtbUpdate) updateEn <- mkRWire;
+    Reg#(Maybe#(BtbUpdate)) updateEn <- mkDReg(Invalid);
 
     function BtbAddr getBtbAddr(Addr pc) = unpack(truncateLSB(pc));
     function BtbBank getBank(Addr pc) = getBtbAddr(pc).bank;

--- a/src_Core/RISCY_OOO/procs/lib/Btb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Btb.bsv
@@ -43,6 +43,7 @@ endinterface
 // Local BTB Typedefs
 typedef 1 PcLsbsIgnore;
 typedef 1024 BtbEntries;
+typedef Bit#(16) CompressedTarget;
 typedef 2 BtbAssociativity;
 typedef Bit#(TLog#(SupSizeX2)) BtbBank;
 // Total entries/lanes of superscalar lookup/associativity
@@ -80,10 +81,12 @@ module mkBtbCore(NextAddrPred#(hashSz))
         Add#(1, a__, TDiv#(tagSz, hashSz)),
     Add#(b__, tagSz, TMul#(TDiv#(tagSz, hashSz), hashSz)));
     // Read and Write ordering doesn't matter since this is a predictor
-    Reg#(BtbBank) firstBank_reg <- mkRegU;
-    Vector#(SupSizeX2, MapSplit#(HashedTag#(hashSz), BtbIndex, VnD#(Addr), BtbAssociativity))
-        records <- replicateM(mkMapLossyBRAM);
-    Reg#(Maybe#(BtbUpdate)) updateEn <- mkDReg(Invalid);
+    Reg#(Addr) addr_reg <- mkRegU;
+    Vector#(SupSizeX2, MapSplit#(HashedTag#(hashSz), BtbIndex, VnD#(Addr), 1))
+        fullRecords <- replicateM(mkMapLossyBRAM);
+    Vector#(SupSizeX2, MapSplit#(HashedTag#(hashSz), BtbIndex, VnD#(CompressedTarget), BtbAssociativity))
+        compressedRecords <- replicateM(mkMapLossyBRAM);
+    RWire#(BtbUpdate) updateEn <- mkRWire;
 
     function BtbAddr getBtbAddr(Addr pc) = unpack(truncateLSB(pc));
     function BtbBank getBank(Addr pc) = getBtbAddr(pc).bank;
@@ -100,27 +103,34 @@ module mkBtbCore(NextAddrPred#(hashSz))
         let taken = upd.taken;
         /*$display("MapUpdate in BTB - pc %x, bank: %x, taken: %x, next: %x, time: %t",
                   pc, getBank(pc), taken, nextPc, $time);*/
-        records[getBank(pc)].update(lookupKey(pc), VnD{v:taken, d:nextPc});
+        CompressedTarget shortMask = -1;
+        CapMem mask = ~zeroExtend(shortMask);
+        if ((pc&mask) == (nextPc&mask))
+            compressedRecords[getBank(pc)].update(lookupKey(pc), VnD{v:taken, d:truncate(nextPc)});
+        else
+            fullRecords[getBank(pc)].update(lookupKey(pc), VnD{v:taken, d:nextPc});
     endrule
 
     method Action put_pc(Addr pc);
-        BtbAddr addr = getBtbAddr(pc);
-        firstBank_reg <= addr.bank;
+        addr_reg <= pc;
         // Start SupSizeX2 BTB lookups, but ensure to lookup in the appropriate
         // bank for the alignment of each potential branch.
         for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1) begin
-            BtbAddr a = unpack(pack(addr));
-            a = unpack({a.tag, {a.index,a.bank} + fromInteger(i)});
-            records[a.bank].lookupStart(MapKeyIndex{key: hash(a.tag), index: a.index});
+            BtbAddr a = unpack(pack(getBtbAddr(pc)) + fromInteger(i));
+            fullRecords[a.bank].lookupStart(MapKeyIndex{key: hash(a.tag), index: a.index});
+            compressedRecords[a.bank].lookupStart(MapKeyIndex{key: hash(a.tag), index: a.index});
         end
     endmethod
 
-    method Vector#(SupSizeX2, Maybe#(Addr)) pred;
-        Vector#(SupSizeX2, Maybe#(Addr)) ppcs = replicate(Invalid);
-        for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1)
-            if (records[i].lookupRead matches tagged Valid .record)
-                ppcs[i] = record.v ? Valid(record.d):Invalid;
-        ppcs = rotateBy(ppcs,unpack(-firstBank_reg)); // Rotate firstBank down to zeroeth element.
+    method Vector#(SupSizeX2, Maybe#(CapMem)) pred;
+        Vector#(SupSizeX2, Maybe#(CapMem)) ppcs = replicate(Invalid);
+        for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1) begin
+            if (fullRecords[i].lookupRead matches tagged Valid .r)
+                ppcs[i] = r.v ? Valid(r.d):Invalid;
+            if (compressedRecords[i].lookupRead matches tagged Valid .r)
+                ppcs[i] = r.v ? Valid({truncateLSB(addr_reg),r.d}):Invalid;
+        end
+        ppcs = rotateBy(ppcs,unpack(-getBtbAddr(addr_reg).bank)); // Rotate firstBank down to zeroeth element.
         return ppcs;
     endmethod
 
@@ -130,9 +140,12 @@ module mkBtbCore(NextAddrPred#(hashSz))
 
 `ifdef SECURITY
     method Action flush method Action flush;
-        for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1) records[i].clear;
+        for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1) begin
+            fullRecords[i].clear;
+            compressedRecords[i].clear;
+        end
     endmethod
-    method flush_done = records[0].clearDone;
+    method flush_done = fullRecords[0].clearDone;
 `else
     method flush = noAction;
     method flush_done = True;

--- a/src_Core/RISCY_OOO/procs/lib/Btb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Btb.bsv
@@ -104,7 +104,7 @@ module mkBtbCore(NextAddrPred#(hashSz))
         /*$display("MapUpdate in BTB - pc %x, bank: %x, taken: %x, next: %x, time: %t",
                   pc, getBank(pc), taken, nextPc, $time);*/
         CompressedTarget shortMask = -1;
-        CapMem mask = ~zeroExtend(shortMask);
+        Addr mask = ~zeroExtend(shortMask);
         if ((pc&mask) == (nextPc&mask))
             compressedRecords[getBank(pc)].update(lookupKey(pc), VnD{v:taken, d:truncate(nextPc)});
         else
@@ -125,8 +125,8 @@ module mkBtbCore(NextAddrPred#(hashSz))
         end
     endmethod
 
-    method Vector#(SupSizeX2, Maybe#(CapMem)) pred;
-        Vector#(SupSizeX2, Maybe#(CapMem)) ppcs = replicate(Invalid);
+    method Vector#(SupSizeX2, Maybe#(Addr)) pred;
+        Vector#(SupSizeX2, Maybe#(Addr)) ppcs = replicate(Invalid);
         for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1) begin
             if (fullRecords[i].lookupRead matches tagged Valid .r)
                 ppcs[i] = r.v ? Valid(r.d):Invalid;

--- a/src_Core/RISCY_OOO/procs/lib/DTlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DTlb.bsv
@@ -466,9 +466,9 @@ module mkDTlb#(
             let trans_result = tlb.translate(vpn, vm_info.asid);
             if (!validVirtualAddress(r.addr)) begin
                 // page fault
-                Exception fault = r.write ? excStorePageFault : excLoadPageFault;
+                Exception fault = r.write ? StorePageFault : LoadPageFault;
                 pendWait[idx] <= None;
-                pendResp[idx] <= tuple3(?, Valid (fault), False);
+                pendResp[idx] <= tuple2(?, Valid (fault));
                 if(verbose) $display("[DTLB] req invalid virtual address: idx %d; ", idx, fshow(r));
             end else if (trans_result.hit) begin
                 // TLB hit

--- a/src_Core/RISCY_OOO/procs/lib/DTlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DTlb.bsv
@@ -464,7 +464,13 @@ module mkDTlb#(
         else if (vm_info.sv39) begin
             let vpn = getVpn(r.addr);
             let trans_result = tlb.translate(vpn, vm_info.asid);
-            if (trans_result.hit) begin
+            if (!validVirtualAddress(r.addr)) begin
+                // page fault
+                Exception fault = r.write ? excStorePageFault : excLoadPageFault;
+                pendWait[idx] <= None;
+                pendResp[idx] <= tuple3(?, Valid (fault), False);
+                if(verbose) $display("[DTLB] req invalid virtual address: idx %d; ", idx, fshow(r));
+            end else if (trans_result.hit) begin
                 // TLB hit
                 let entry = trans_result.entry;
                 // check permission

--- a/src_Core/RISCY_OOO/procs/lib/EpochManager.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/EpochManager.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -24,6 +24,7 @@
 `include "ProcConfig.bsv"
 import Vector::*;
 import Ehr::*;
+import ConfigReg::*;
 import Types::*;
 import ProcTypes::*;
 
@@ -53,8 +54,8 @@ endinterface
 
 (* synthesize *)
 module mkEpochManager(EpochManager);
-    Reg#(Epoch) curr_epoch <- mkReg(0);
-    Reg#(Epoch) prev_checked_epoch <- mkReg(0);
+    Reg#(Epoch) curr_epoch <- mkConfigReg(0);
+    Reg#(Epoch) prev_checked_epoch <- mkConfigReg(0);
     Epoch next_epoch = (curr_epoch== fromInteger(valueOf(NumEpochs)-1)) ? 0 : (curr_epoch+1);
 
     // epochs in the core are within range [prev_checked_epoch, curr_epoch]
@@ -130,4 +131,3 @@ module mkEpochManager(EpochManager);
         return next_epoch == prev_checked_epoch;
     endmethod
 endmodule
-

--- a/src_Core/RISCY_OOO/procs/lib/Fpu.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Fpu.bsv
@@ -82,7 +82,7 @@ module mkDoubleDiv(Server#(Tuple3#(Double, Double, FpuRoundMode), Tuple2#(Double
 `ifdef USE_XILINX_FPU
     let fpu <- mkXilinxFpDiv;
 `else
-    let int_div <- mkDivider(1); // [sizhuo] size in RVFpu: 2
+    let int_div <- mkNonPipelinedDivider(3);
     let fpu <- mkFloatingPointDivider(int_div);
 `endif
     return fpu;
@@ -93,7 +93,7 @@ module mkDoubleSqrt(Server#(Tuple2#(Double, FpuRoundMode), Tuple2#(Double, FpuEx
 `ifdef USE_XILINX_FPU
     let fpu <- mkXilinxFpSqrt;
 `else
-    let int_sqrt <- mkSquareRooter(1); // [sizhuo] size in RVFpu: 3
+    let int_sqrt <- mkNonPipelinedSquareRooter(3);
     let fpu <- mkFloatingPointSquareRooter(int_sqrt);
 `endif
     return fpu;
@@ -331,7 +331,7 @@ function Tuple2#(Bit#(64), FpuException) float_to_int(
         // necessary for rounding and overflow detection.
         Bit#(TAdd#(66,m)) int_val = {64'b1, in.sfd, 2'b0}; // this is 2**m times larger than it should be - we will shift this to correct for that
         int_val = saturating_shift_right(int_val, fromInteger(valueOf(m)) + bias_exp - in_exp);
-        
+
         // do rounding
         // 00 : exact
         // 01 : < 0.5
@@ -950,4 +950,3 @@ module mkFpuExecPipeline(FpuExec);
         sqrtQ.specUpdate
     ));
 endmodule
-

--- a/src_Core/RISCY_OOO/procs/lib/GSelectPred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/GSelectPred.bsv
@@ -33,6 +33,9 @@ export GSelectGHistSz;
 export GSelectGHist;
 export GSelectTrainInfo;
 export mkGSelectPred;
+export PCIndexSz;
+export BhtIndexSz;
+export BhtIndex;
 
 // 1KB gselect predictor
 
@@ -47,6 +50,7 @@ typedef Bit#(BhtIndexSz) BhtIndex;
 // bookkeeping info a branch should keep for future training
 typedef struct {
     GSelectGHist gHist;
+    BhtIndex index;
 } GSelectTrainInfo deriving(Bits, Eq, FShow);
 
 // global history
@@ -69,6 +73,9 @@ module mkGSelectPred(DirPredictor#(GSelectTrainInfo));
     // EHR to record predict results in this cycle
     Ehr#(TAdd#(1, SupSize), Bit#(TLog#(TAdd#(SupSize, 1)))) predCnt <- mkEhr(0);
     Ehr#(TAdd#(1, SupSize), Bit#(SupSize)) predRes <- mkEhr(0);
+
+    // Lookup PC
+    Reg#(Addr) pc_reg <- mkRegU;
 
     function BhtIndex getIndex(Addr pc, GSelectGHist gHist);
         Bit#(PCIndexSz) pcIdx = truncate(pc >> 2);
@@ -93,13 +100,14 @@ module mkGSelectPred(DirPredictor#(GSelectTrainInfo));
     Vector#(SupSize, DirPred#(GSelectTrainInfo)) predIfc;
     for(Integer i = 0; i < valueof(SupSize); i = i+1) begin
         predIfc[i] = (interface DirPred;
-            method ActionValue#(DirPredResult#(GSelectTrainInfo)) pred(Addr pc);
+            method ActionValue#(DirPredResult#(GSelectTrainInfo)) pred;
                 // get the global history
                 // all previous branch in this cycle must be not taken
                 // otherwise this branch should be on wrong path
                 // because all inst in same cycle are fetched consecutively
                 GSelectGHist gHist = curGHist >> predCnt[i];
-                Bool taken = isTaken(tab.sub(getIndex(pc, gHist)));
+                BhtIndex index = getIndex(offsetPc(pc_reg, i), gHist);
+                Bool taken = isTaken(tab.sub(index));
 
                 // record pred result
                 predCnt[i] <= predCnt[i] + 1;
@@ -111,7 +119,8 @@ module mkGSelectPred(DirPredictor#(GSelectTrainInfo));
                 return DirPredResult {
                     taken: taken,
                     train: GSelectTrainInfo {
-                        gHist: gHist
+                        gHist: gHist,
+                        index: index
                     }
                 };
             endmethod
@@ -125,16 +134,18 @@ module mkGSelectPred(DirPredictor#(GSelectTrainInfo));
         predCnt[valueof(SupSize)] <= 0;
     endrule
 
+    method nextPc = pc_reg._write;
+
     interface pred = predIfc;
 
-    method Action update(Addr pc, Bool taken, GSelectTrainInfo train, Bool mispred);
+    method Action update(Bool taken, GSelectTrainInfo train, Bool mispred);
         // update history if mispred
         if(mispred) begin
             GSelectGHist newHist = truncate({pack(taken), train.gHist} >> 1);
             globalHist.redirect(newHist);
         end
         // update sat cnt
-        let index = getIndex(pc, train.gHist);
+        let index = train.index;
         Bit#(2) cnt = tab.sub(index);
         tab.upd(index, updateCnt(cnt, taken));
     endmethod

--- a/src_Core/RISCY_OOO/procs/lib/GSharePred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/GSharePred.bsv
@@ -33,6 +33,8 @@ export GShareGHistSz;
 export GShareGHist;
 export GShareTrainInfo;
 export mkGSharePred;
+export BhtIndexSz;
+export BhtIndex;
 
 // 16KB gshare predictor (to match BOOM evaluation paper)
 
@@ -47,6 +49,7 @@ typedef Bit#(BhtIndexSz) BhtIndex;
 // bookkeeping info a branch should keep for future training
 typedef struct {
     GShareGHist gHist;
+    BhtIndex index;
 } GShareTrainInfo deriving(Bits, Eq, FShow);
 
 // global history
@@ -69,6 +72,9 @@ module mkGSharePred(DirPredictor#(GShareTrainInfo));
     // EHR to record predict results in this cycle
     Ehr#(TAdd#(1, SupSize), Bit#(TLog#(TAdd#(SupSize, 1)))) predCnt <- mkEhr(0);
     Ehr#(TAdd#(1, SupSize), Bit#(SupSize)) predRes <- mkEhr(0);
+
+    // Lookup PC
+    Reg#(Addr) pc_reg <- mkRegU;
 
     function BhtIndex getIndex(Addr pc, GShareGHist gHist);
         Bit#(PCIndexSz) pcIdx = truncate(pc >> 2);
@@ -93,13 +99,14 @@ module mkGSharePred(DirPredictor#(GShareTrainInfo));
     Vector#(SupSize, DirPred#(GShareTrainInfo)) predIfc;
     for(Integer i = 0; i < valueof(SupSize); i = i+1) begin
         predIfc[i] = (interface DirPred;
-            method ActionValue#(DirPredResult#(GShareTrainInfo)) pred(Addr pc);
+            method ActionValue#(DirPredResult#(GShareTrainInfo)) pred;
                 // get the global history
                 // all previous branch in this cycle must be not taken
                 // otherwise this branch should be on wrong path
                 // because all inst in same cycle are fetched consecutively
                 GShareGHist gHist = curGHist >> predCnt[i];
-                Bool taken = isTaken(tab.sub(getIndex(pc, gHist)));
+                BhtIndex index = getIndex(offsetPc(pc_reg, i), gHist);
+                Bool taken = isTaken(tab.sub(index));
 
                 // record pred result
                 predCnt[i] <= predCnt[i] + 1;
@@ -111,7 +118,8 @@ module mkGSharePred(DirPredictor#(GShareTrainInfo));
                 return DirPredResult {
                     taken: taken,
                     train: GShareTrainInfo {
-                        gHist: gHist
+                        gHist: gHist,
+                        index: index
                     }
                 };
             endmethod
@@ -125,18 +133,19 @@ module mkGSharePred(DirPredictor#(GShareTrainInfo));
         predCnt[valueof(SupSize)] <= 0;
     endrule
 
+    method nextPc = pc_reg._write;
+
     interface pred = predIfc;
 
-    method Action update(Addr pc, Bool taken, GShareTrainInfo train, Bool mispred);
+    method Action update(Bool taken, GShareTrainInfo train, Bool mispred);
         // update history if mispred
         if(mispred) begin
             GShareGHist newHist = truncate({pack(taken), train.gHist} >> 1);
             globalHist.redirect(newHist);
         end
         // update sat cnt
-        let index = getIndex(pc, train.gHist);
-        Bit#(2) cnt = tab.sub(index);
-        tab.upd(index, updateCnt(cnt, taken));
+        Bit#(2) cnt = tab.sub(train.index);
+        tab.upd(train.index, updateCnt(cnt, taken));
     endmethod
 
     method flush = noAction;

--- a/src_Core/RISCY_OOO/procs/lib/GlobalSpecUpdate.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/GlobalSpecUpdate.bsv
@@ -26,7 +26,7 @@ import HasSpecBits::*;
 import GetPut::*;
 import Vector::*;
 import ReorderBuffer::*;
-import FIFO::*;
+import SpecFifo::*;
 
 typedef struct {
     Bool kill_all;
@@ -36,13 +36,14 @@ typedef struct {
 
 interface GlobalSpecUpdate#(numeric type correctSpecPortNum, numeric type conflictWrongSpecPortNum);
     interface Vector#(correctSpecPortNum, Put#(SpecTag)) correctSpec;
-    method Action incorrectSpec(Bool kill_all, SpecTag spec_tag, InstTag inst_tag);
+    method Action incorrectSpec(Bool kill_all, SpecTag spec_tag, InstTag inst_tag, SpecBits spec_bits);
     // Some rules (e.g. doFinishFpuMulDiv) in Core.bsv may not conflict with wrong spec
     // and is ordered before rules that calls incorrectSpec
     // this creates cycles in scheduling
     // To break the cycle, such rules can call the following interface
     // to manually create a conflict with rules that do incorrectSpec
     interface Vector#(conflictWrongSpecPortNum, Put#(void)) conflictWrongSpec;
+    method Bool pendingIncorrectSpec;
 endinterface
 
 module mkGlobalSpecUpdate#(
@@ -54,12 +55,12 @@ module mkGlobalSpecUpdate#(
     // record correct spec tags
     Vector#(correctSpecPortNum, RWire#(SpecTag)) correctSpecTag <- replicateM(mkRWire);
     // make wrong spec conflict with correct spec
-    Vector#(correctSpecPortNum, RWire#(void)) spec_conflict <- replicateM(mkRWire);
+    Vector#(correctSpecPortNum, PulseWire) spec_conflict <- replicateM(mkPulseWire);
     // let the caller of conflictWrongSpec to be conflict with wrong spec
-    Vector#(conflictWrongSpecPortNum, RWire#(void)) wrongSpec_conflict <- replicateM(mkRWire);
+    Vector#(conflictWrongSpecPortNum, PulseWire) wrongSpec_conflict <- replicateM(mkPulseWire);
     // must be a single-element fifo to ensure all pushing rules cannot fire while we are waiting
     // to kill.
-    FIFO#(IncorrectSpec) incorrectSpec_ff <- mkFIFO1;
+    SpecFifo#(2,IncorrectSpec,1,1) incorrectSpec_ff <- mkSpecFifoCF(True);
 
     (* fire_when_enabled, no_implicit_conditions *)
     rule canon_correct_spec;
@@ -69,31 +70,32 @@ module mkGlobalSpecUpdate#(
                 mask[tag] = 0;
             end
         end
+        incorrectSpec_ff.specUpdate.correctSpeculation(mask);
         ifc.correctSpeculation(mask);
         rob.correctSpeculation(mask);
     endrule
 
     rule do_incorrect_spec;
-        IncorrectSpec x <- toGet(incorrectSpec_ff).get;
+        IncorrectSpec x = incorrectSpec_ff.first.data;
+        incorrectSpec_ff.deq;
+        incorrectSpec_ff.specUpdate.incorrectSpeculation(x.kill_all, x.spec_tag);
         ifc.incorrectSpeculation(x.kill_all, x.spec_tag);
         rob.incorrectSpeculation(x.kill_all, x.spec_tag, x.inst_tag);
         // conflict with correct spec
         for(Integer i = 0; i < valueof(correctSpecPortNum); i = i+1) begin
-            spec_conflict[i].wset(?);
+            spec_conflict[i].send;
         end
         // conflict with the caller of conflictWrongSpec
         for(Integer i = 0; i < valueof(conflictWrongSpecPortNum); i = i+1) begin
-            wrongSpec_conflict[i].wset(?);
+            wrongSpec_conflict[i].send;
         end
     endrule
 
     Vector#(correctSpecPortNum, Put#(SpecTag)) correctVec = ?;
     for(Integer i = 0; i < valueof(correctSpecPortNum); i = i+1) begin
         correctVec[i] = (interface Put;
-            method Action put(SpecTag t);
+            method Action put(SpecTag t) if (!spec_conflict[i]);
                 correctSpecTag[i].wset(t);
-                // conflict with wrong spec
-                spec_conflict[i].wset(?);
             endmethod
         endinterface);
     end
@@ -101,16 +103,21 @@ module mkGlobalSpecUpdate#(
     Vector#(conflictWrongSpecPortNum, Put#(void)) conflictWrongVec = ?;
     for(Integer i = 0; i < valueof(conflictWrongSpecPortNum); i = i+1) begin
         conflictWrongVec[i] = (interface Put;
-            method Action put(void x);
-                wrongSpec_conflict[i].wset(?);
+            method Action put(void x) if (!wrongSpec_conflict[i]);
+                noAction;
             endmethod
         endinterface);
     end
 
     interface correctSpec = correctVec;
 
-    method Action incorrectSpec(Bool kill_all, SpecTag spec_tag, InstTag inst_tag)
-        = incorrectSpec_ff.enq(IncorrectSpec{kill_all: kill_all, spec_tag: spec_tag, inst_tag: inst_tag});
+    method Action incorrectSpec(Bool kill_all, SpecTag spec_tag, InstTag inst_tag, SpecBits spec_bits)
+        = incorrectSpec_ff.enq(ToSpecFifo{
+              data: IncorrectSpec{kill_all: kill_all, spec_tag: spec_tag, inst_tag: inst_tag},
+              spec_bits: spec_bits
+          });
 
     interface conflictWrongSpec = conflictWrongVec;
+
+    method Bool pendingIncorrectSpec = incorrectSpec_ff.notEmpty;
 endmodule

--- a/src_Core/RISCY_OOO/procs/lib/LatencyTimer.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/LatencyTimer.bsv
@@ -23,6 +23,7 @@
 
 import Vector::*;
 import Types::*;
+import ConfigReg::*;
 
 // a timer to track latency of multiple misses
 
@@ -39,8 +40,8 @@ module mkLatencyTimer(LatencyTimer#(num, timeWidth)) provisos(
     Alias#(idxT, Bit#(TLog#(num))),
     Alias#(timeT, Bit#(timeWidth))
 );
-    Reg#(Vector#(num, timeT)) timer <- mkReg(replicate(0));
-    Reg#(Vector#(num, Bool)) started <- mkReg(replicate(False)); // for checking purposes
+    Reg#(Vector#(num, timeT)) timer <- mkConfigReg(replicate(0));
+    Reg#(Vector#(num, Bool)) started <- mkConfigReg(replicate(False)); // for checking purposes
 
     RWire#(idxT) startEn <- mkRWire;
     RWire#(idxT) doneEn <- mkRWire;

--- a/src_Core/RISCY_OOO/procs/lib/PhysRFile.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/PhysRFile.bsv
@@ -63,7 +63,7 @@ module mkRFile#(Bool lazy)( RFile#(wrNum, rdNum) ) provisos (
     // which must be 0 at all time
     // Using a mkRegOR here assumes there will be a single write per register per cycle.
     // As each register is allocated to a single instruction which will execute once, this should always be true.
-    Vector#(NumPhyReg, Vector#(ehrPortNum, Reg#(Data))) rfile <- replicateM(mkRegOR(?));
+    Vector#(NumPhyReg, Vector#(ehrPortNum, Reg#(Data))) rfile <- replicateM(mkRegOR(0));
 
     Vector#(NumPhyReg, Data) rdData = ?;
     if(lazy) begin

--- a/src_Core/RISCY_OOO/procs/lib/PhysRFile.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/PhysRFile.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -34,6 +34,7 @@ import ProcTypes::*;
 import Vector::*;
 import Ehr::*;
 import ConfigReg::*;
+import SpecialRegs::*;
 
 interface RFileWr;
     method Action wr( PhyRIndx rindx, Data data );
@@ -60,7 +61,9 @@ module mkRFile#(Bool lazy)( RFile#(wrNum, rdNum) ) provisos (
 
     // phy reg init val must be 0: because x0 is renamed to phy reg 0,
     // which must be 0 at all time
-    Vector#(NumPhyReg, Ehr#(ehrPortNum, Data)) rfile <- replicateM(mkEhr(0));
+    // Using a mkRegOR here assumes there will be a single write per register per cycle.
+    // As each register is allocated to a single instruction which will execute once, this should always be true.
+    Vector#(NumPhyReg, Vector#(ehrPortNum, Reg#(d))) rfile <- replicateM(mkRegOR(defaultRegisterValue));
 
     Vector#(NumPhyReg, Data) rdData = ?;
     if(lazy) begin

--- a/src_Core/RISCY_OOO/procs/lib/PhysRFile.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/PhysRFile.bsv
@@ -63,7 +63,7 @@ module mkRFile#(Bool lazy)( RFile#(wrNum, rdNum) ) provisos (
     // which must be 0 at all time
     // Using a mkRegOR here assumes there will be a single write per register per cycle.
     // As each register is allocated to a single instruction which will execute once, this should always be true.
-    Vector#(NumPhyReg, Vector#(ehrPortNum, Reg#(d))) rfile <- replicateM(mkRegOR(defaultRegisterValue));
+    Vector#(NumPhyReg, Vector#(ehrPortNum, Reg#(Data))) rfile <- replicateM(mkRegOR(?));
 
     Vector#(NumPhyReg, Data) rdData = ?;
     if(lazy) begin

--- a/src_Core/RISCY_OOO/procs/lib/ReorderBuffer.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ReorderBuffer.bsv
@@ -513,7 +513,7 @@ module mkSupReorderBuffer#(
     Add#(1, a__, aluExeNum), Add#(1, b__, fpuMulDivExeNum)
 );
 
-    Bool verbose = False;
+    Bool verbose = True;
 
     // doCommit rule: deq < wrongSpec (overwrite deq in doCommit) < doRenaming rule: enq
     Integer valid_deq_port = 0;
@@ -595,6 +595,7 @@ module mkSupReorderBuffer#(
                 // move deqP & reset valid
                 deqP[i] <= getNextPtr(deqP[i]);
                 valid[i][deqP[i]][valid_deq_port] <= False;
+                $display("deq[%d][%d]", i, deqP[i]);
             end
         end
         // update firstDeqWay: find the first deq port that is not enabled
@@ -774,6 +775,9 @@ module mkSupReorderBuffer#(
                     end
                 endfunction
                 for(Integer i = 0; i < valueof(SingleScalarSize); i = i+1) begin
+                    if (in_kill_range(fromInteger(i)) != (row[w][i].dependsOn_wrongSpec(specTag) && valid[w][i][valid_wrongSpec_port]))
+                        $display("enqP: %d, enqPNext: %d, w: %d, i: %d, wrongSpec: %d, valid: %d, cur_cycle: %d",
+                            enqP[w], enqPNext[w], w, i, row[w][i].dependsOn_wrongSpec(specTag), valid[w][i][valid_wrongSpec_port], cur_cycle);
                     doAssert(
                         in_kill_range(fromInteger(i)) ==
                         (row[w][i].dependsOn_wrongSpec(specTag) && valid[w][i][valid_wrongSpec_port]),

--- a/src_Core/RISCY_OOO/procs/lib/ReorderBuffer.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ReorderBuffer.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -237,13 +237,13 @@ module mkReorderBufferRowEhr(ReorderBufferRowEhr#(aluExeNum, fpuMulDivExeNum)) p
             endmethod
         endinterface);
     end
-    
+
     Vector#(fpuMulDivExeNum, Row_setExecuted_doFinishFpuMulDiv) fpuMulDivExe;
     for(Integer i = 0; i < valueof(fpuMulDivExeNum); i = i+1) begin
         fpuMulDivExe[i] = (interface Row_setExecuted_doFinishFpuMulDiv;
             method Action set(Data dst_data, Bit#(5) new_fflags);
                 // inst is done
-                rob_inst_state[state_finishFpuMulDiv_port(i)] <= Executed; 
+                rob_inst_state[state_finishFpuMulDiv_port(i)] <= Executed;
 	        rg_dst_data <= dst_data;
                 // update fflags
                 fflags[fflags_finishFpuMulDiv_port(i)] <= new_fflags;
@@ -455,7 +455,7 @@ interface SupReorderBuffer#(numeric type aluExeNum, numeric type fpuMulDivExeNum
 
     interface Vector#(SupSize, ROB_DeqPort) deqPort;
 
-    // record that we have notified LSQ about inst reaching commit 
+    // record that we have notified LSQ about inst reaching commit
     method Action setLSQAtCommitNotified(InstTag x);
     // deqLSQ rules set ROB state
     method Action setExecuted_deqLSQ(InstTag x, Maybe#(Exception) cause, Maybe#(LdKilledBy) ld_killed);
@@ -513,7 +513,7 @@ module mkSupReorderBuffer#(
     Add#(1, a__, aluExeNum), Add#(1, b__, fpuMulDivExeNum)
 );
 
-    Bool verbose = True;
+    Bool verbose = False;
 
     // doCommit rule: deq < wrongSpec (overwrite deq in doCommit) < doRenaming rule: enq
     Integer valid_deq_port = 0;
@@ -595,7 +595,7 @@ module mkSupReorderBuffer#(
                 // move deqP & reset valid
                 deqP[i] <= getNextPtr(deqP[i]);
                 valid[i][deqP[i]][valid_deq_port] <= False;
-                $display("deq[%d][%d]", i, deqP[i]);
+                if (verbose) $display("deq[%d][%d]", i, deqP[i]);
             end
         end
         // update firstDeqWay: find the first deq port that is not enabled
@@ -775,7 +775,7 @@ module mkSupReorderBuffer#(
                     end
                 endfunction
                 for(Integer i = 0; i < valueof(SingleScalarSize); i = i+1) begin
-                    if (in_kill_range(fromInteger(i)) != (row[w][i].dependsOn_wrongSpec(specTag) && valid[w][i][valid_wrongSpec_port]))
+                    if (verbose && in_kill_range(fromInteger(i)) != (row[w][i].dependsOn_wrongSpec(specTag) && valid[w][i][valid_wrongSpec_port]))
                         $display("enqP: %d, enqPNext: %d, w: %d, i: %d, wrongSpec: %d, valid: %d, cur_cycle: %d",
                             enqP[w], enqPNext[w], w, i, row[w][i].dependsOn_wrongSpec(specTag), valid[w][i][valid_wrongSpec_port], cur_cycle);
                     doAssert(

--- a/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
@@ -24,6 +24,8 @@
 import ProcTypes::*;
 import HasSpecBits::*;
 import Vector::*;
+import FIFOF::*;
+import ConfigReg::*;
 import Ehr::*;
 import Assert::*;
 import Types::*;
@@ -41,6 +43,7 @@ interface SpecFifo#(
     method Action enq(ToSpecFifo#(t) x);
     method Action deq;
     method ToSpecFifo#(t) first;
+    method Bool notEmpty;
     interface SpeculationUpdate specUpdate;
 endinterface
 
@@ -164,6 +167,8 @@ module mkSpecFifo#(
         };
     endmethod
 
+    method Bool notEmpty = valid[deqP][sched.validDeqPort];
+
     interface SpeculationUpdate specUpdate;
         method Action correctSpeculation(SpecBits mask);
             // clear spec bits for all entries
@@ -194,6 +199,126 @@ module mkSpecFifo#(
             wrongSpec_canon_conflict.send;
             wrongSpec_deq_conflict.send;
         endmethod
+    endinterface
+endmodule
+
+typedef struct {
+    Bool kill_all;
+    SpecTag specTag;
+} IncorrectSpeculation deriving(Bits, Eq, FShow);
+
+module mkSpecFifoCF#(
+    Bool lazyEnq // whether we calculate enq guard lazily
+)(
+    SpecFifo#(size, t, validPortNum, sbPortNum)
+) provisos (
+    Alias#(idxT, Bit#(TLog#(size))),
+    Bits#(t, _tsz),
+    FShow#(t)
+);
+    // correct spec is always the last
+    Integer sbCorrectSpecPort = valueof(sbPortNum) - 1;
+
+    Ehr#(3, Vector#(size, Bool))             valid    <- mkEhr(replicate(False));
+    Vector#(size, Reg#(t))                   row      <- replicateM(mkConfigRegU);
+    Ehr#(3, Vector#(size, SpecBits))         specBits <- mkEhr(?);
+
+    FIFOF#(SpecBits)                     correctSpecF <- mkUGFIFOF;
+    FIFOF#(IncorrectSpeculation)       incorrectSpecF <- mkUGFIFOF;
+
+    Reg#(idxT) enqP <- mkConfigReg(0);
+    Ehr#(2, idxT) deqP_ehr <- mkEhr(0);
+    Reg#(idxT) deqP = deqP_ehr[0]; // port 0 is for deq and canon_deqP
+
+    function idxT getNextPtr(idxT p);
+        return p == fromInteger(valueOf(size) - 1) ? 0 : p + 1;
+    endfunction
+
+    Bool empty_for_canon = all( \== (False) , valid[0] );
+    rule canon_deqP(!valid[1][deqP] && (enqP != deqP || !empty_for_canon));
+        // element at deqP was killed, so increment deqP
+        deqP <= getNextPtr(deqP);
+    endrule
+
+    (* fire_when_enabled, no_implicit_conditions *)
+    rule canon_speculation;
+        Vector#(size, SpecBits) newSpecBits = specBits[0];
+        Vector#(size, Bool) newValid = valid[0];
+        // Fold in CorrectSpec update:
+        if (correctSpecF.notEmpty) begin
+            SpecBits mask = correctSpecF.first();
+            correctSpecF.deq();
+            // clear spec bits for all entries
+            for (Integer i=0; i<valueOf(size); i=i+1)
+                newSpecBits[i] = newSpecBits[i] & mask;
+        end
+        // Fold in IncorrectSpec update:
+        if (incorrectSpecF.notEmpty) begin
+            IncorrectSpeculation incSpec = incorrectSpecF.first();
+            incorrectSpecF.deq();
+            // clear entries
+            for (Integer i=0; i<valueOf(size); i=i+1)
+                if(incSpec.kill_all || newSpecBits[i][incSpec.specTag] == 1'b1)
+                    newValid[i] = False;
+        end
+        specBits[0] <= newSpecBits;
+        valid[0] <= newValid;
+    endrule
+
+    // calculate guard for enq, we can do aggressively or lazily
+    idxT deqP_for_enq = ?;
+    Bool empty_for_enq = ?;
+    Bool valid_for_enq = ?;
+    if(lazyEnq) begin
+        // use the stale deqP & valid before canon_deqP or deq fires
+        // because deq, canon_deqP, wrongSpec only set valid to false and move deqP forward
+        // this just makes enq fire less aggressively
+        Wire#(idxT) deqP_for_enq_wire <- mkBypassWire;
+        Wire#(Bool) empty_for_enq_wire <- mkBypassWire;
+        Wire#(Bool) valid_for_enq_wire <- mkBypassWire;
+        (* fire_when_enabled, no_implicit_conditions *)
+        rule setWireForEnq;
+            deqP_for_enq_wire <= deqP;
+            empty_for_enq_wire <= all( \== (False) , valid[1] );
+            valid_for_enq_wire <= valid[1][enqP];
+        endrule
+        deqP_for_enq = deqP_for_enq_wire;
+        empty_for_enq = empty_for_enq_wire;
+        valid_for_enq = valid_for_enq_wire;
+    end
+    else begin
+        deqP_for_enq = deqP_ehr[1]; // read up-to-date deqP
+        empty_for_enq = all( \== (False) , valid[2] );
+        valid_for_enq = valid[2][enqP];
+    end
+
+    method Action enq(ToSpecFifo#(t) x) if (empty_for_enq || enqP != deqP_for_enq);
+        // [sizhuo] I don't think valid bit needs to be checked here
+        doAssert(!valid_for_enq, "enq entry cannot be valid");
+        row[enqP] <= x.data;
+        valid[2][enqP] <= True;
+        specBits[2][enqP] <= x.spec_bits;
+        enqP <= getNextPtr(enqP);
+    endmethod
+
+    method Action deq if (valid[1][deqP]);
+        valid[1][deqP] <= False;
+        deqP <= getNextPtr(deqP);
+    endmethod
+
+    method ToSpecFifo#(t) first if (valid[1][deqP]);
+        return ToSpecFifo{
+            data: row[deqP],
+            spec_bits: specBits[1][deqP]
+        };
+    endmethod
+
+    method Bool notEmpty = valid[1][deqP];
+
+    interface SpeculationUpdate specUpdate;
+        method correctSpeculation = correctSpecF.enq;
+        method incorrectSpeculation(kill_all, specTag) =
+            incorrectSpecF.enq(IncorrectSpeculation{kill_all: kill_all, specTag: specTag});
     endinterface
 endmodule
 

--- a/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
@@ -86,21 +86,21 @@ module mkSpecFifo#(
     Reg#(idxT) deqP = deqP_ehr[0]; // port 0 is for deq and canon_deqP
 
     // make incorrectSpeculation conflict with others
-    RWire#(void) dummyRWire = (interface RWire;
-        method Maybe#(void) wget = Invalid;
-        method Action wset(void x) = noAction;
-    endinterface);
-    RWire#(void) wrongSpec_enq_conflict = dummyRWire;
-    RWire#(void) wrongSpec_deq_conflict = dummyRWire;
-    RWire#(void) wrongSpec_canon_conflict = dummyRWire;
+    PulseWire dummyPulseWire = interface PulseWire;
+        method Bool _read = False;
+        method Action send = noAction;
+    endinterface;
+    PulseWire wrongSpec_enq_conflict = dummyPulseWire;
+    PulseWire wrongSpec_deq_conflict = dummyPulseWire;
+    PulseWire wrongSpec_canon_conflict = dummyPulseWire;
     if(sched.wrongSpec_conflict_enq) begin
-        wrongSpec_enq_conflict <- mkRWire;
+        wrongSpec_enq_conflict <- mkPulseWire;
     end
     if(sched.wrongSpec_conflict_deq) begin
-        wrongSpec_deq_conflict <- mkRWire;
+        wrongSpec_deq_conflict <- mkPulseWire;
     end
     if(sched.wrongSpec_conflict_canon) begin
-        wrongSpec_canon_conflict <- mkRWire;
+        wrongSpec_canon_conflict <- mkPulseWire;
     end
 
     function idxT getNextPtr(idxT p);
@@ -108,11 +108,10 @@ module mkSpecFifo#(
     endfunction
 
     Bool empty_for_canon = all( \== (False) , readVEhr(sched.validDeqPort, valid) );
-    rule canon_deqP(!valid[deqP][sched.validDeqPort] && (enqP != deqP || !empty_for_canon));
+    rule canon_deqP(!valid[deqP][sched.validDeqPort] && (enqP != deqP || !empty_for_canon)
+                     && !wrongSpec_canon_conflict); // make conflict with incorrect spec
         // element at deqP was killed, so increment deqP
         deqP <= getNextPtr(deqP);
-        // make conflict with incorrect spec
-        wrongSpec_canon_conflict.wset(?);
     endrule
 
     // calculate guard for enq, we can do aggressively or lazily
@@ -142,22 +141,20 @@ module mkSpecFifo#(
         valid_for_enq = valid[enqP][sched.validEnqPort];
     end
 
-    method Action enq(ToSpecFifo#(t) x) if (empty_for_enq || enqP != deqP_for_enq);
+    method Action enq(ToSpecFifo#(t) x) if ((empty_for_enq || enqP != deqP_for_enq)
+                                            && !wrongSpec_enq_conflict); // make conflict with incorrect spec
         // [sizhuo] I don't think valid bit needs to be checked here
         doAssert(!valid_for_enq, "enq entry cannot be valid");
         enqP <= getNextPtr(enqP);
         valid[enqP][sched.validEnqPort] <= True;
         row[enqP] <= x.data;
         specBits[enqP][sched.sbEnqPort] <= x.spec_bits;
-        // make conflict with incorrect spec
-        wrongSpec_enq_conflict.wset(?);
     endmethod
 
-    method Action deq if (valid[deqP][sched.validDeqPort]);
+    method Action deq if (valid[deqP][sched.validDeqPort]
+                          && !wrongSpec_deq_conflict); // make conflict with incorrect spec
         valid[deqP][sched.validDeqPort] <= False;
         deqP <= getNextPtr(deqP);
-        // make conflict with incorrect spec
-        wrongSpec_deq_conflict.wset(?);
     endmethod
 
     method ToSpecFifo#(t) first if (valid[deqP][sched.validDeqPort]);
@@ -193,9 +190,9 @@ module mkSpecFifo#(
             Vector#(size, Integer) idxVec = genVector;
             joinActions(map(incorrectSpec, idxVec));
             // make conflict with others
-            wrongSpec_enq_conflict.wset(?);
-            wrongSpec_canon_conflict.wset(?);
-            wrongSpec_deq_conflict.wset(?);
+            wrongSpec_enq_conflict.send;
+            wrongSpec_canon_conflict.send;
+            wrongSpec_deq_conflict.send;
         endmethod
     endinterface
 endmodule

--- a/src_Core/RISCY_OOO/procs/lib/TlbTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TlbTypes.bsv
@@ -1,6 +1,6 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -49,7 +49,7 @@ typedef 44 PpnSz;
 typedef Bit#(PpnSz) Ppn;
 typedef 12 PageOffsetSz; // 4KB basic page
 typedef Bit#(PageOffsetSz) PageOffset;
-typedef 9 VpnIdxSz; // Vpn is broken down to 3 indexes to 3 levels of page table 
+typedef 9 VpnIdxSz; // Vpn is broken down to 3 indexes to 3 levels of page table
 typedef Bit#(VpnIdxSz) VpnIdx;
 typedef Bit#(2) PageWalkLevel; // 2: 1GB page, 1: 2MB page, 0: 4KB page
 typedef 3 NumPageWalkLevels;
@@ -86,6 +86,9 @@ typedef struct {
 function Vpn getVpn(Addr addr) = addr[38:12];
 
 function PageOffset getPageOffset(Addr addr) = truncate(addr);
+
+// All the upper bits should be equal for a valid SV39 virtual address.
+function Bool validVirtualAddress(Addr addr) = ((addr[63:39] ^ {addr[39],addr[63:40]}) == 0);
 
 function Addr getPTBaseAddr(Ppn basePpn);
     PageOffset offset = 0;

--- a/src_Core/RISCY_OOO/procs/lib/TlbTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TlbTypes.bsv
@@ -88,7 +88,7 @@ function Vpn getVpn(Addr addr) = addr[38:12];
 function PageOffset getPageOffset(Addr addr) = truncate(addr);
 
 // All the upper bits should be equal for a valid SV39 virtual address.
-function Bool validVirtualAddress(Addr addr) = ((addr[63:39] ^ {addr[39],addr[63:40]}) == 0);
+function Bool validVirtualAddress(Addr addr) =  (addr[63:39] == {addr[39],addr[63:40]});
 
 function Addr getPTBaseAddr(Ppn basePpn);
     PageOffset offset = 0;

--- a/src_Core/RISCY_OOO/procs/lib/TourPred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TourPred.bsv
@@ -101,6 +101,8 @@ module mkTourPred(DirPredictor#(TourTrainInfo));
     endfunction
 
     TourGlobalHist curGHist = gHistReg.history; // global history: MSB is the latest branch
+    Reg#(Vector#(SupSize, Bool)) globalTakenVec <- mkRegU;
+    Reg#(Vector#(SupSize, Bool)) useLocalVec <- mkRegU;
 
     Vector#(SupSize, DirPred#(TourTrainInfo)) predIfc;
     for(Integer i = 0; i < valueof(SupSize); i = i+1) begin
@@ -114,12 +116,11 @@ module mkTourPred(DirPredictor#(TourTrainInfo));
                 // all previous branch in this cycle must be not taken
                 // otherwise this branch should be on wrong path
                 // because all inst in same cycle are fetched consecutively
-                TourGlobalHist globalHist = curGHist >> predCnt[i];
                 // get global prediction
-                Bool globalTaken = isTaken(globalBht.sub(globalHist));
+                Bool globalTaken = globalTakenVec[predCnt[i]];
 
                 // make choice
-                Bool useLocal = isTaken(choiceBht.sub(globalHist));
+                Bool useLocal = useLocalVec[predCnt[i]];
                 Bool taken = useLocal ? localTaken : globalTaken;
 
                 // record prediction
@@ -132,7 +133,7 @@ module mkTourPred(DirPredictor#(TourTrainInfo));
                 return DirPredResult {
                     taken: taken,
                     train: TourTrainInfo {
-                        globalHist: globalHist,
+                        globalHist: curGHist >> predCnt[i],
                         localHist: localHist,
                         globalTaken: globalTaken,
                         localTaken: localTaken
@@ -145,6 +146,14 @@ module mkTourPred(DirPredictor#(TourTrainInfo));
     (* fire_when_enabled, no_implicit_conditions *)
     rule canonGlobalHist;
         gHistReg.addHistory(predRes[valueof(SupSize)], predCnt[valueof(SupSize)]);
+        // Buffer useLocalVec
+        // Reproduce next history; this would ideally be done in GlobalBrHistReg to avoid duplicating logic.
+        TourGlobalHist nHist = truncate({predRes[valueof(SupSize)], curGHist} >> predCnt[valueof(SupSize)]);
+        function Bool globalTakenLookup (Integer i) = isTaken(globalBht.sub(nHist >> i));
+        function Bool useLocalLookup (Integer i) = isTaken(choiceBht.sub(nHist >> i));
+        globalTakenVec <= genWith(globalTakenLookup);
+        useLocalVec <= genWith(useLocalLookup);
+        // Reset counters and prediction.
         predRes[valueof(SupSize)] <= 0;
         predCnt[valueof(SupSize)] <= 0;
     endrule

--- a/src_Core/RISCY_OOO/procs/lib/TourPredSecure.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TourPredSecure.bsv
@@ -60,7 +60,6 @@ typedef TExp#(LgGlobalVecSz) GlobalVecSz;
 typedef Bit#(GlobalVecSz) GlobalVecSelect;
 
 typedef struct {
-    Addr pc;
     Bool taken;
     TourTrainInfo train;
     Bool mispred;
@@ -80,6 +79,9 @@ module mkTourPredSecure(DirPredictor#(TourTrainInfo));
     // choice sat counters: large (taken) -- use local, small (not taken) -- use global
     RegFile#(TabIndex, Vector#(GlobalVecSz, Bit#(2))) choiceBht <- mkRegFileWCF(0, maxBound);
 
+    // Lookup PC
+    Reg#(Addr) pc_reg <- mkRegU;
+
     // EHR to record predict results in this cycle
     Ehr#(TAdd#(1, SupSize), SupCnt) predCnt <- mkEhr(0);
     Ehr#(TAdd#(1, SupSize), Bit#(SupSize)) predRes <- mkEhr(0);
@@ -90,8 +92,9 @@ module mkTourPredSecure(DirPredictor#(TourTrainInfo));
     Reg#(Bool) flushDone <- mkReg(True);
     Reg#(TabIndex) flushIndex <- mkReg(0);
 
-    function Tuple2#(TabIndex, LocalHistVecSelect) getPCIndex(Addr pc);
-        PCIndex pcIdx = truncate(pc >> 2);
+    function PCIndex getPCIndex(Addr pc) = truncate(pc >> 2);
+
+    function Tuple2#(TabIndex, LocalHistVecSelect) getPCIndices(PCIndex pcIdx);
         TabIndex tabIdx = truncateLSB(pcIdx);
         LocalHistVecSelect sel = truncate(pcIdx);
         return tuple2(tabIdx, sel);
@@ -129,9 +132,10 @@ module mkTourPredSecure(DirPredictor#(TourTrainInfo));
     Vector#(SupSize, DirPred#(TourTrainInfo)) predIfc;
     for(Integer i = 0; i < valueof(SupSize); i = i+1) begin
         predIfc[i] = (interface DirPred;
-            method ActionValue#(DirPredResult#(TourTrainInfo)) pred(Addr pc);
+            method ActionValue#(DirPredResult#(TourTrainInfo)) pred;
                 // get local history
-                let {localHistTabIdx, localHistVecSel} = getPCIndex(pc);
+                PCIndex pcIndex = getPCIndex(offsetPc(pc_reg, i));
+                let {localHistTabIdx, localHistVecSel} = getPCIndices(pcIndex);
                 Vector#(LocalHistVecSz, TourLocalHist) localHistVec = localHistTab.sub(localHistTabIdx);
                 TourLocalHist localHist = localHistVec[localHistVecSel];
                 // get local prediction
@@ -167,7 +171,8 @@ module mkTourPredSecure(DirPredictor#(TourTrainInfo));
                         globalHist: globalHist,
                         localHist: localHist,
                         globalTaken: globalTaken,
-                        localTaken: localTaken
+                        localTaken: localTaken,
+                        pcIndex: pcIndex
                     }
                 };
             endmethod
@@ -184,7 +189,6 @@ module mkTourPredSecure(DirPredictor#(TourTrainInfo));
     // no flush, accept update
     (* fire_when_enabled, no_implicit_conditions *)
     rule canonUpdate(flushDone &&& updateEn.wget matches tagged Valid .upd);
-        let pc = upd.pc;
         let taken = upd.taken;
         let train = upd.train;
         let mispred = upd.mispred;
@@ -196,7 +200,7 @@ module mkTourPredSecure(DirPredictor#(TourTrainInfo));
         end
 
         // update local history (assume only 1 branch for an PC in flight)
-        let {localHistTabIdx, localHistVecSel} = getPCIndex(pc);
+        let {localHistTabIdx, localHistVecSel} = getPCIndices(train.pcIndex);
         Vector#(LocalHistVecSz, TourLocalHist) localHistVec = localHistTab.sub(localHistTabIdx);
         localHistVec[localHistVecSel] = truncateLSB({pack(taken), train.localHist});
         localHistTab.upd(localHistTabIdx, localHistVec);
@@ -238,10 +242,12 @@ module mkTourPredSecure(DirPredictor#(TourTrainInfo));
         end
     endrule
 
+    method nextPc = pc_reg._write;
+
     interface pred = predIfc;
 
-    method Action update(Addr pc, Bool taken, TourTrainInfo train, Bool mispred);
-        updateEn.wset(TourUpdate {pc: pc, taken: taken, train: train, mispred: mispred});
+    method Action update(Bool taken, TourTrainInfo train, Bool mispred);
+        updateEn.wset(TourUpdate {taken: taken, train: train, mispred: mispred});
     endmethod
 
     method Action flush if(flushDone);

--- a/src_Testbench/Fabrics/AXI4/AXI4_Mem_Model.bsv
+++ b/src_Testbench/Fabrics/AXI4/AXI4_Mem_Model.bsv
@@ -71,7 +71,7 @@ module mkAXI4_Mem_Model (AXI4_Mem_Model_IFC #(wd_id, wd_addr, wd_data, wd_user))
 	     NumAlias #(wd_data, 64));
 
    // 0 = quiet; 1 = show mem transactions
-   Integer verbosity = 1;
+   Integer verbosity = 0;
 
    Reg #(Bool) rg_initialized <- mkReg (False);
 


### PR DESCRIPTION
These are a raft of improvements that we have made to our CHERI branch which apply to general performance.

1. Scheduling improvements
Toooba (RISCYOO) previously required that many, many rules in the pipeline conflict with any rule that could report a mispeculation. (Specifically, two ALU rules that finished a misspeculated branch, or some commit rules.) Many rules in the pipeline that consumed speculative state would have to dynamically wait for the conditions of those rules to resolve before they could fire. This both caused timing issues, due to the dynamic dependencies on these rules, and also bluespec scheduling issues, as these rules had to fit into a schedule relative to all the others.  In this patch, the issue is greatly alleviated from multiple angles.  Firstly, the wrongSpec report is deterministically always given priority. (Previously this was left up to the scheduler, and the wrong decision would cost ~10% cycles CoreMark, for example.) This also simplifies the code.  Secondly, the wrongSpec report is buffered in GlobalSpecUpdate so that all rules that are dependent on the broadcast depend only on the one broadcast rule.  Buffering is also added in SpecFifo modules, though changes are applied before any reads in the next cycle, so there is no logical change.  These changes resulted in small amounts of additional improved performance presumably due to decoupling the scheduling of rules that previously were deemed to conflict.

2. Timing improvements.
Several rounds of timing improvements were made in an attempt to reach 50MHz on the Stratix X with two cores. These included buffering and pre-calculation in branch prediction modules, as well as approximating the decode epoch so that prediction could progress more in parallel.

3. Area improvements.
Mainly using NonPipelined versions of the Divider and SquareRooter in the FPU.  This can reduce area by about 10%.  There is also now compression in the BTB, with n ways of compressed targets (where the upper bits (>16) of the target match the branch PC), and a single way is dedicated to full branch targets. This one also improves performance, as an associativity of 2 for the BTB now has an extra way for "far" branches.

These changes have been tested with synthesis (dual core) and booting FreeBSD on the vcu118.

There should be some need to clean up these commits a bit, so feel free to comment!