### PR TITLE
Master memory optimize

### DIFF
--- a/src_Core/RISCY_OOO/coherence/src/CCPipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/CCPipe.bsv
@@ -121,7 +121,7 @@ typedef struct {
     CacheInfo#(tagT, msiT, dirT, ownerT, otherT) info;
     repT repInfo;
     // bypassed or resp line
-    lineT line;
+    Maybe#(lineT) line;
 } Match2Out#(
     type wayT,
     type tagT,
@@ -164,7 +164,7 @@ typedef struct {
     msiT cs;
     dirT dir;
 } UpdateByDownDir#(type msiT, type dirT) deriving(Bits, Eq, FShow);
-/*
+
 // index to data ram: {way, normal index}
 function dataIndexT getDataRamIndex(wayT w, indexT i) provisos(
     Alias#(wayT, Bit#(_waySz)),
@@ -173,7 +173,7 @@ function dataIndexT getDataRamIndex(wayT w, indexT i) provisos(
 );
     return {w, i};
 endfunction
-*/
+
 module mkCCPipe#(
     ReadOnly#(Bool) initDone,
     function indexT getIndex(pipeCmdT cmd),
@@ -196,7 +196,7 @@ module mkCCPipe#(
     function ActionValue#(repT) updateRepInfo(repT oldRep, wayT hitWay),
     Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam,
     RWBramCore#(indexT, repT) repRam,
-    Vector#(wayNum, RWBramCore#(dataIndexT, lineT)) dataRam
+    RWBramCore#(dataIndexT, lineT) dataRam
 )(
     CCPipe#(wayNum, indexT, tagT, msiT, dirT, ownerT, otherT, repT, lineT, pipeCmdT)
 ) provisos (
@@ -218,6 +218,240 @@ module mkCCPipe#(
     Bits#(lineT, _lineSz),
     Bits#(pipeCmdT, _pipeCmdSz),
     // index to data ram: {way, normal index}
+    Alias#(dataIndexT, Bit#(TAdd#(TLog#(wayNum), _indexSz)))
+);
+
+    // pipeline regs
+
+    Ehr#(3, Maybe#(enq2MatchT)) enq2Mat <- mkEhr(Invalid);
+    // port 0: bypass
+    Reg#(Maybe#(enq2MatchT)) enq2Mat_bypass = enq2Mat[0];
+    // port 1: tag match
+    Reg#(Maybe#(enq2MatchT)) enq2Mat_match = enq2Mat[1];
+    // port 2: enq
+    Reg#(Maybe#(enq2MatchT)) enq2Mat_enq = enq2Mat[2];
+
+    Ehr#(2, Maybe#(match2OutT)) mat2Out <- mkEhr(Invalid);
+    // port 0: out
+    Reg#(Maybe#(match2OutT)) mat2Out_out = mat2Out[0];
+    // port 1: tag match
+    Reg#(Maybe#(match2OutT)) mat2Out_match = mat2Out[1];
+
+    // bypass write to ram
+    RWire#(bypassInfoT) bypass <- mkRWire;
+
+    // stage 2: first get bypass
+    (* fire_when_enabled, no_implicit_conditions *)
+    rule doMatch_bypass(isValid(bypass.wget) && isValid(enq2Mat_bypass) && initDone);
+        bypassInfoT b = fromMaybe(?, bypass.wget);
+        enq2MatchT e2m = fromMaybe(?, enq2Mat_bypass);
+        if(b.index == getIndex(e2m.cmd)) begin
+            e2m.infoVec[b.way] = Valid (b.ram.info);
+            e2m.repInfo = Valid (b.repInfo);
+        end
+        enq2Mat_bypass <= Valid (e2m);
+    endrule
+
+    rule doTagMatch(isValid(enq2Mat_match) && !isValid(mat2Out_match) && initDone);
+        enq2MatchT e2m = fromMaybe(?, enq2Mat_match);
+        // get cache output & merge with bypass
+        Vector#(wayNum, infoT) infoVec;
+        for(Integer i = 0; i < valueOf(wayNum); i = i+1) begin
+            infoRam[i].deqRdResp;
+            infoVec[i] = fromMaybe(infoRam[i].rdResp, e2m.infoVec[i]);
+        end
+        repRam.deqRdResp;
+        repT repInfo = fromMaybe(repRam.rdResp, e2m.repInfo);
+        // do tag match to get way to occupy
+        Vector#(wayNum, tagT) tagVec;
+        Vector#(wayNum, msiT) csVec;
+        Vector#(wayNum, ownerT) ownerVec;
+        for(Integer i = 0; i < valueOf(wayNum); i = i+1) begin
+            tagVec[i] = infoVec[i].tag;
+            csVec[i] = infoVec[i].cs;
+            ownerVec[i] = infoVec[i].owner;
+        end
+        let tmRes <- tagMatch(e2m.cmd, tagVec, csVec, ownerVec, repInfo);
+        wayT way = tmRes.way;
+        Bool pRqMiss = tmRes.pRqMiss;
+        // read data
+        indexT index = getIndex(e2m.cmd);
+        dataRam.rdReq(getDataRamIndex(way, index));
+        // set mat2out & merge with CRs/PRs & merge with data bypass
+        // resp data has higher priority than data bypass
+        match2OutT m2o = Match2Out {
+            cmd: e2m.cmd,
+            way: way,
+            pRqMiss: pRqMiss,
+            info: infoVec[way],
+            repInfo: repInfo,
+            line: e2m.respLine
+        };
+        if(e2m.toState matches tagged UpCs .s) begin
+            UpdateByUpCs#(msiT) upd <- updateByUpCs(
+                e2m.cmd, s, isValid(e2m.respLine), m2o.info.cs
+            );
+            m2o.info.cs = upd.cs;
+        end
+        else if(e2m.toState matches tagged DownDir .s) begin
+            UpdateByDownDir#(msiT, dirT) upd <- updateByDownDir(
+                e2m.cmd, s, isValid(e2m.respLine), m2o.info.cs, m2o.info.dir
+            );
+            m2o.info.cs = upd.cs;
+            m2o.info.dir = upd.dir;
+        end
+        if(bypass.wget matches tagged Valid .b &&& b.index == index &&& b.way == way &&& !isValid(m2o.line)) begin
+            // bypass has lower priority than resp data
+            m2o.line = Valid (b.ram.line);
+        end
+        mat2Out_match <= Valid (m2o);
+        // reset enq2mat
+        enq2Mat_match <= Invalid;
+    endrule
+
+    // construct output with bypass/resp data
+    function pipeOutT firstOut;
+        match2OutT m2o = fromMaybe(?, mat2Out_out);
+        return PipeOut {
+            cmd: m2o.cmd,
+            way: m2o.way,
+            pRqMiss: m2o.pRqMiss,
+            ram: RamData {
+                info: m2o.info,
+                line: fromMaybe(dataRam.rdResp, m2o.line)
+            },
+            repInfo: m2o.repInfo
+        };
+    endfunction
+
+    Bool enq_guard = !isValid(enq2Mat_enq) && initDone;
+
+    Bool deq_guard = isValid(mat2Out_out) && initDone;
+
+    // stage 1: enq req to pipeline: access info+rep RAM & bypass
+    method Action enq(pipeCmdT cmd, Maybe#(lineT) respLine, respStateT toState) if(enq_guard);
+        // read ram
+        indexT index = getIndex(cmd);
+        for(Integer i = 0; i < valueOf(wayNum); i = i+1) begin
+            infoRam[i].rdReq(index);
+        end
+        repRam.rdReq(index);
+        // write reg & get bypass
+        enq2MatchT e2m = Enq2Match {
+            cmd: cmd,
+            infoVec: replicate(Invalid),
+            repInfo: Invalid,
+            respLine: respLine,
+            toState: toState
+        };
+        if(bypass.wget matches tagged Valid .b &&& b.index == index) begin
+            e2m.infoVec[b.way] = Valid (b.ram.info);
+            e2m.repInfo = Valid (b.repInfo);
+        end
+        enq2Mat_enq <= Valid (e2m);
+    endmethod
+
+    method Bool notFull = enq_guard;
+
+    method pipeOutT first if(deq_guard);
+        return firstOut;
+    endmethod
+
+    method pipeOutT unguard_first;
+        return firstOut;
+    endmethod
+
+    method Bool notEmpty = deq_guard;
+
+    method Action deqWrite(Maybe#(pipeCmdT) newCmd, ramDataT wrRam, Bool updateRep) if(deq_guard);
+        match2OutT m2o = fromMaybe(?, mat2Out_out);
+        wayT way = m2o.way;
+        indexT index = getIndex(m2o.cmd);
+        // update replacement info
+        repT repInfo = m2o.repInfo;
+        if(updateRep) begin
+            repInfo <- updateRepInfo(m2o.repInfo, way);
+        end
+        // write ram
+        infoRam[way].wrReq(index, wrRam.info);
+        repRam.wrReq(index, repInfo);
+        dataRam.wrReq(getDataRamIndex(way, index), wrRam.line);
+        // set bypass to Enq and Match stages
+        bypass.wset(BypassInfo {
+            index: index,
+            way: way,
+            ram: wrRam,
+            repInfo: repInfo
+        });
+        // change pipeline reg
+        if(newCmd matches tagged Valid .cmd) begin
+            // update pipeline reg
+            mat2Out_out <= Valid (Match2Out {
+                cmd: cmd, // swapped in new cmd
+                way: way, // keep way same
+                pRqMiss: False, // reset (not valid for swapped in pRq)
+                info: wrRam.info, // get bypass
+                repInfo: repInfo, // get bypass
+                line: Valid (wrRam.line) // get bypass
+            });
+        end
+        else begin
+            // XXX deq ram resp, I think this should not block
+            dataRam.deqRdResp;
+            // reset pipeline reg
+            mat2Out_out <= Invalid;
+        end
+    endmethod
+
+    method Bool emptyForFlush;
+        return !isValid(mat2Out[0]) && !isValid(enq2Mat[0]);
+    endmethod
+endmodule
+
+module mkCCPipeSingleCycle#(
+    ReadOnly#(Bool) initDone,
+    function indexT getIndex(pipeCmdT cmd),
+    function ActionValue#(TagMatchResult#(wayT)) tagMatch(
+        // actionvalue enable us to do checking inside the function
+        pipeCmdT cmd,
+        // below are current RAM outputs, is merged with ram write from final stage
+        // but is NOT merged with state changes carried in PRs/CRs
+        Vector#(wayNum, tagT) tagVec,
+        Vector#(wayNum, msiT) csVec,
+        Vector#(wayNum, ownerT) ownerVec,
+        repT repInfo
+    ),
+    function ActionValue#(UpdateByUpCs#(msiT)) updateByUpCs(
+        pipeCmdT cmd, msiT toState, Bool dataValid, msiT oldCs
+    ),
+    function ActionValue#(UpdateByDownDir#(msiT, dirT)) updateByDownDir(
+        pipeCmdT cmd, msiT toState, Bool dataValid, msiT oldCs, dirT oldDir
+    ),
+    function ActionValue#(repT) updateRepInfo(repT oldRep, wayT hitWay),
+    Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam,
+    RWBramCore#(indexT, repT) repRam,
+    // Must be BRAMs with integrated forwarding; e.g. mkRWBramCoreForwarded
+    Vector#(wayNum, RWBramCore#(dataIndexT, lineT)) dataRam
+)(
+    CCPipe#(wayNum, indexT, tagT, msiT, dirT, ownerT, otherT, repT, lineT, pipeCmdT)
+) provisos (
+    Alias#(wayT, Bit#(TLog#(wayNum))),
+    Alias#(indexT, Bit#(_indexSz)),
+    Alias#(infoT, CacheInfo#(tagT, msiT, dirT, ownerT, otherT)),
+    Alias#(ramDataT, RamData#(tagT, msiT, dirT, ownerT, otherT, lineT)),
+    Alias#(respStateT, RespState#(msiT)),
+    Alias#(pipeOutT, PipeOut#(wayT, tagT, msiT, dirT, ownerT, otherT, repT, lineT, pipeCmdT)),
+    Alias#(enq2MatchT, Enq2Match#(wayNum, tagT, msiT, dirT, ownerT, otherT, repT, lineT, pipeCmdT)),
+    Alias#(match2OutT, Match2Out#(wayT, tagT, msiT, dirT, ownerT, otherT, repT, lineT, pipeCmdT)),
+    Alias#(bypassInfoT, BypassInfo#(wayT, indexT, tagT, msiT, dirT, ownerT, otherT, repT, lineT)),
+    Bits#(tagT, _tagSz),
+    Bits#(msiT, _msiSz),
+    Bits#(dirT, _dirSz),
+    Bits#(ownerT, _ownerSz),
+    Bits#(otherT, _otherSz),
+    Bits#(repT, _repSz),
+    Bits#(lineT, _lineSz),
+    Bits#(pipeCmdT, _pipeCmdSz),
     Alias#(dataIndexT, Bit#(_indexSz))
 );
 
@@ -268,7 +502,7 @@ module mkCCPipe#(
             pRqMiss: pRqMiss,
             info: infoVec[way],
             repInfo: repInfo,
-            line: fromMaybe(dataVec[way],e2m.respLine)
+            line: isValid(e2m.respLine) ? e2m.respLine:Valid(dataVec[way])
         };
         if(e2m.toState matches tagged UpCs .s) begin
             UpdateByUpCs#(msiT) upd <- updateByUpCs(
@@ -283,12 +517,9 @@ module mkCCPipe#(
             m2o.info.cs = upd.cs;
             m2o.info.dir = upd.dir;
         end
-        indexT index = getIndex(e2m.cmd);
-        if (e2m.respLine matches tagged Valid .rl) begin
-            m2o.line = rl;
-        end else begin
-            m2o.line = dataVec[way];
-        end mat2Out_match <= Valid (m2o);
+        //indexT index = getIndex(e2m.cmd);
+        //m2o.line = isValid(e2m.respLine) ? e2m.respLine:Valid(dataVec[way]);
+        mat2Out_match <= Valid (m2o);
         // reset enq2mat
         enq2Mat_match <= Invalid;
     endrule
@@ -302,7 +533,7 @@ module mkCCPipe#(
             pRqMiss: m2o.pRqMiss,
             ram: RamData {
                 info: m2o.info,
-                line: m2o.line
+                line: m2o.line.Valid
             },
             repInfo: m2o.repInfo
         };
@@ -367,7 +598,7 @@ module mkCCPipe#(
                 pRqMiss: False, // reset (not valid for swapped in pRq)
                 info: wrRam.info,
                 repInfo: repInfo,
-                line: wrRam.line
+                line: Valid(wrRam.line)
             });
         end
         else begin

--- a/src_Core/RISCY_OOO/coherence/src/L1Pipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/L1Pipe.bsv
@@ -1,6 +1,7 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+// Copyright (c) 2020 Jonathan Woodruff
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +9,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -77,7 +78,7 @@ typedef union tagged {
 } L1PipeIn#(
     type wayT,
     type indexT,
-    type cRqIdxT, 
+    type cRqIdxT,
     type pRqIdxT
 ) deriving (Bits, Eq, FShow);
 
@@ -96,7 +97,7 @@ typedef union tagged {
 `endif
 } L1Cmd#(
     type indexT,
-    type cRqIdxT, 
+    type cRqIdxT,
     type pRqIdxT
 ) deriving (Bits, Eq, FShow);
 
@@ -105,12 +106,12 @@ interface L1Pipe#(
     numeric type wayNum,
     type indexT,
     type tagT,
-    type cRqIdxT, 
+    type cRqIdxT,
     type pRqIdxT
 );
     method Action send(L1PipeIn#(Bit#(TLog#(wayNum)), indexT, cRqIdxT, pRqIdxT) r);
     method PipeOut#(
-        Bit#(TLog#(wayNum)), 
+        Bit#(TLog#(wayNum)),
         tagT, Msi, void, // no dir
         Maybe#(cRqIdxT), void, RandRepInfo, // no other
         Line, L1Cmd#(indexT, cRqIdxT, pRqIdxT)
@@ -138,7 +139,7 @@ typedef union tagged {
 } L1PipeCmd#(
     type wayT,
     type indexT,
-    type cRqIdxT, 
+    type cRqIdxT,
     type pRqIdxT
 ) deriving (Bits, Eq, FShow);
 
@@ -173,10 +174,10 @@ module mkL1Pipe(
    Bool verbose = False;
 
     // RAMs
-    Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam <- replicateM(mkRWBramCore);
+    Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam <- replicateM(mkRWBramCoreForwarded);
     RWBramCore#(indexT, repT) repRam <- mkRandRepRam;
-    RWBramCore#(dataIndexT, Line) dataRam <- mkRWBramCore;
-    
+    Vector#(wayNum, RWBramCore#(indexT, Line)) dataRam <- replicateM(mkRWBramCoreForwarded);
+
     // initialize RAM
     Reg#(Bool) initDone <- mkReg(False);
     Reg#(indexT) initIndex <- mkReg(0);
@@ -222,22 +223,22 @@ module mkL1Pipe(
 
     function ActionValue#(tagMatchResT) tagMatch(
         pipeCmdT cmd,
-        Vector#(wayNum, tagT) tagVec, 
-        Vector#(wayNum, Msi) csVec, 
+        Vector#(wayNum, tagT) tagVec,
+        Vector#(wayNum, Msi) csVec,
         Vector#(wayNum, ownerT) ownerVec,
         repT repInfo
     );
         return actionvalue
             function tagT getTag(Addr a) = truncateLSB(a);
 
-	    if (verbose)
-            $display("%t L1 %m tagMatch: ", $time, 
-                fshow(cmd), " ; ", 
-                fshow(getTag(getAddrFromCmd(cmd))),
-                fshow(tagVec), " ; ", 
-                fshow(csVec), " ; ", 
-                fshow(ownerVec), " ; " 
-            );
+	        if (verbose)
+                $display("%t L1 %m tagMatch: ", $time, 
+                    fshow(cmd), " ; ", 
+                    fshow(getTag(getAddrFromCmd(cmd))),
+                    fshow(tagVec), " ; ",
+                    fshow(csVec), " ; ",
+                    fshow(ownerVec), " ; "
+                );
             if(cmd matches tagged PRs .rs) begin
                 // PRs directly read from cmd
                 return TagMatchResult {

--- a/src_Core/RISCY_OOO/coherence/src/L1Pipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/L1Pipe.bsv
@@ -328,7 +328,7 @@ module mkL1Pipe(
 
     CCPipe#(
         wayNum, indexT, tagT, Msi, dirT, ownerT, otherT, repT, Line, pipeCmdT
-    ) pipe <- mkCCPipe(
+    ) pipe <- mkCCPipeSingleCycle(
         regToReadOnly(initDone), getIndex, tagMatch,
         updateByUpCs, updateByDownDir, updateRepInfo,
         infoRam, repRam, dataRam

--- a/src_Core/RISCY_OOO/coherence/src/LLPipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/LLPipe.bsv
@@ -1,6 +1,7 @@
 
 // Copyright (c) 2017 Massachusetts Institute of Technology
-// 
+// Copyright (c) 2020 Jonathan Woodruff
+//
 // Permission is hereby granted, free of charge, to any person
 // obtaining a copy of this software and associated documentation
 // files (the "Software"), to deal in the Software without
@@ -8,10 +9,10 @@
 // modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -138,7 +139,7 @@ module mkLLPipe(
     Alias#(updateByUpCsT, UpdateByUpCs#(Msi)),
     Alias#(updateByDownDirT, UpdateByDownDir#(Msi, dirT)),
     Alias#(dataIndexT, Bit#(TAdd#(TLog#(wayNum), indexSz))),
-    // requirement 
+    // requirement
     Alias#(indexT, Bit#(indexSz)),
     Alias#(tagT, Bit#(tagSz)),
     Alias#(cRqIdxT, Bit#(_cRqIdxSz)),
@@ -151,8 +152,8 @@ module mkLLPipe(
     // RAMs
     Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam <- replicateM(mkRWBramCore);
     RWBramCore#(indexT, repT) repRam <- mkRandRepRam;
-    RWBramCore#(dataIndexT, Line) dataRam <- mkRWBramCore;
-    
+    Vector#(wayNum, RWBramCore#(indexT, Line)) dataRam <- replicateM(mkRWBramCore);
+
     // initialize RAM
     Reg#(Bool) initDone <- mkReg(False);
     Reg#(indexT) initIndex <- mkReg(0);
@@ -194,22 +195,22 @@ module mkLLPipe(
 
     function ActionValue#(tagMatchResT) tagMatch(
         pipeCmdT cmd,
-        Vector#(wayNum, tagT) tagVec, 
-        Vector#(wayNum, Msi) csVec, 
+        Vector#(wayNum, tagT) tagVec,
+        Vector#(wayNum, Msi) csVec,
         Vector#(wayNum, ownerT) ownerVec,
         repT repInfo
     );
         return actionvalue
             function tagT getTag(Addr a) = truncateLSB(a);
 
-	    if (verbose)
-            $display("%t LL %m tagMatch: ", $time, 
-                fshow(cmd), " ; ", 
-                fshow(getTag(getAddrFromCmd(cmd))), " ; ",
-                fshow(tagVec), " ; ", 
-                fshow(csVec), " ; ", 
-                fshow(ownerVec)
-            );
+            if (verbose)
+                $display("%t LL %m tagMatch: ", $time,
+                    fshow(cmd), " ; ",
+                    fshow(getTag(getAddrFromCmd(cmd))), " ; ",
+                    fshow(tagVec), " ; ",
+                    fshow(csVec), " ; ",
+                    fshow(ownerVec)
+                );
             if(cmd matches tagged MRs .rs) begin
                 // MRs directly read from cmd
                 return TagMatchResult {

--- a/src_Core/RISCY_OOO/coherence/src/LLPipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/LLPipe.bsv
@@ -150,9 +150,9 @@ module mkLLPipe(
    Bool verbose = False;
 
     // RAMs
-    Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam <- replicateM(mkRWBramCore);
+    Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam <- replicateM(mkRWBramCoreForwarded);
     RWBramCore#(indexT, repT) repRam <- mkRandRepRam;
-    Vector#(wayNum, RWBramCore#(indexT, Line)) dataRam <- replicateM(mkRWBramCore);
+    Vector#(wayNum, RWBramCore#(indexT, Line)) dataRam <- replicateM(mkRWBramCoreForwarded);
 
     // initialize RAM
     Reg#(Bool) initDone <- mkReg(False);

--- a/src_Core/RISCY_OOO/coherence/src/LLPipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/LLPipe.bsv
@@ -150,9 +150,9 @@ module mkLLPipe(
    Bool verbose = False;
 
     // RAMs
-    Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam <- replicateM(mkRWBramCoreForwarded);
+    Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam <- replicateM(mkRWBramCore);
     RWBramCore#(indexT, repT) repRam <- mkRandRepRam;
-    Vector#(wayNum, RWBramCore#(indexT, Line)) dataRam <- replicateM(mkRWBramCoreForwarded);
+    RWBramCore#(dataIndexT, Line) dataRam <- mkRWBramCore;
 
     // initialize RAM
     Reg#(Bool) initDone <- mkReg(False);

--- a/src_Core/RISCY_OOO/coherence/src/RWBramCore.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/RWBramCore.bsv
@@ -22,6 +22,7 @@
 
 import BRAMCore::*;
 import Fifos::*;
+import RegFile::*;
 
 interface RWBramCore#(type addrT, type dataT);
     method Action wrReq(addrT a, dataT d);
@@ -63,49 +64,18 @@ module mkRWBramCore(RWBramCore#(addrT, dataT)) provisos(
 endmodule
 
 module mkRWBramCoreForwarded(RWBramCore#(addrT, dataT)) provisos(
-    Bits#(addrT, addrSz), Bits#(dataT, dataSz), Eq#(addrT)
-);
-    BRAM_DUAL_PORT#(addrT, dataT) bram <- mkBRAMCore2(valueOf(TExp#(addrSz)), False);
-    BRAM_PORT#(addrT, dataT) wrPort = bram.a;
-    BRAM_PORT#(addrT, dataT) rdPort = bram.b;
-    // 1 elem pipeline fifo to add guard for read req/resp
-    // must be 1 elem to make sure rdResp is not corrupted
-    // BRAMCore should not change output if no req is made
-    Fifo#(1, Maybe#(dataT)) rdReqQ <- mkPipelineFifo;
-    RWire#(addrT) currentWriteAddr <- mkRWire;
-    RWire#(dataT) currentWriteData <- mkRWire;
+        Bits#(addrT, addr_sz),
+        Bounded#(addrT),
+        Bits#(dataT, data_sz));
 
-    method Action wrReq(addrT a, dataT d);
-        wrPort.put(True, a, d);
-        currentWriteAddr.wset(a); //Forward data, if read happens on same cycle
-        currentWriteData.wset(d);
-    endmethod
+	  RegFile#(addrT,dataT) regFile <- mkRegFileWCF(minBound, maxBound); // BRAM
+	  Fifo#(1, addrT) readReq <- mkPipelineFifo;
 
-    method Action rdReq(addrT a);
-        if (currentWriteAddr.wget matches tagged Valid .writeAddr &&& writeAddr == a) begin
-            //$display ("%t Write same addr as read -- forwarding data!", $time);
-            rdReqQ.enq(Valid(fromMaybe(?, currentWriteData.wget)));
-        end
-        else begin
-            rdReqQ.enq(Invalid);
-        end
-        rdPort.put(False, a, ?);
-    endmethod
-
-    method dataT rdResp if(rdReqQ.notEmpty);
-        if (rdReqQ.first matches tagged Valid .data) begin
-            return data;
-        end
-        else begin
-            return rdPort.read;
-        end
-    endmethod
-
-    method rdRespValid = rdReqQ.notEmpty;
-
-    method Action deqRdResp;
-        rdReqQ.deq;
-    endmethod
+  	method Action rdReq(addrT a) = readReq.enq(a);
+    method dataT rdResp() = regFile.sub(readReq.first());
+    method rdRespValid = readReq.notEmpty;
+    method Action deqRdResp = readReq.deq();
+    method Action wrReq(addrT a, dataT x) = regFile.upd(a,x);
 endmodule
 
 module mkRWBramCoreUG(RWBramCore#(addrT, dataT)) provisos(

--- a/src_Core/RISCY_OOO/coherence/src/RWBramCore.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/RWBramCore.bsv
@@ -22,7 +22,6 @@
 
 import BRAMCore::*;
 import Fifos::*;
-import RegFile::*;
 
 interface RWBramCore#(type addrT, type dataT);
     method Action wrReq(addrT a, dataT d);
@@ -64,18 +63,43 @@ module mkRWBramCore(RWBramCore#(addrT, dataT)) provisos(
 endmodule
 
 module mkRWBramCoreForwarded(RWBramCore#(addrT, dataT)) provisos(
-        Bits#(addrT, addr_sz),
-        Bounded#(addrT),
-        Bits#(dataT, data_sz));
+    Bits#(addrT, addrSz), Bits#(dataT, dataSz), Eq#(addrT)
+);
+    BRAM_DUAL_PORT#(addrT, dataT) bram <- mkBRAMCore2(valueOf(TExp#(addrSz)), False);
+    BRAM_PORT#(addrT, dataT) wrPort = bram.a;
+    BRAM_PORT#(addrT, dataT) rdPort = bram.b;
+    // 1 elem pipeline fifo to add guard for read req/resp
+    // must be 1 elem to make sure rdResp is not corrupted
+    // BRAMCore should not change output if no req is made
+    Fifo#(1, void) rdReqQ <- mkPipelineFifo;
+    Reg#(addrT) readAddr[2] <- mkCReg(2,?);
+    Reg#(addrT) currentWriteAddr <- mkRegU;
+    Reg#(dataT) currentWriteData <- mkRegU;
 
-	  RegFile#(addrT,dataT) regFile <- mkRegFileWCF(minBound, maxBound); // BRAM
-	  Fifo#(1, addrT) readReq <- mkPipelineFifo;
+    rule doRead;
+        rdPort.put(False, readAddr[1], ?);
+    endrule
 
-  	method Action rdReq(addrT a) = readReq.enq(a);
-    method dataT rdResp() = regFile.sub(readReq.first());
-    method rdRespValid = readReq.notEmpty;
-    method Action deqRdResp = readReq.deq();
-    method Action wrReq(addrT a, dataT x) = regFile.upd(a,x);
+    method Action wrReq(addrT a, dataT d);
+        wrPort.put(True, a, d);
+        currentWriteAddr <= a; //Forward data, if read happens on same cycle
+        currentWriteData <= d;
+    endmethod
+
+    method Action rdReq(addrT a);
+        readAddr[0] <= a;
+        rdReqQ.enq(?);
+    endmethod
+
+    method dataT rdResp if(rdReqQ.notEmpty);
+        return (readAddr[0] == currentWriteAddr) ? currentWriteData : rdPort.read;
+    endmethod
+
+    method rdRespValid = rdReqQ.notEmpty;
+
+    method Action deqRdResp;
+        rdReqQ.deq;
+    endmethod
 endmodule
 
 module mkRWBramCoreUG(RWBramCore#(addrT, dataT)) provisos(

--- a/src_Core/RISCY_OOO/coherence/src/SelfInvIPipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/SelfInvIPipe.bsv
@@ -246,7 +246,7 @@ module mkSelfInvIPipe(
     // rep RAM (dummy)
     RWBramCore#(indexT, repT) repRam <- mkRandRepRam;
     // data RAM
-    RWBramCore#(dataIndexT, Line) dataRam <- mkRWBramCore;
+    Vector#(wayNum, RWBramCore#(indexT, Line)) dataRam <- replicateM(mkRWBramCoreForwarded);
 
     // initialize RAM
     Reg#(Bool) initDone <- mkReg(False);

--- a/src_Core/RISCY_OOO/coherence/src/SelfInvIPipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/SelfInvIPipe.bsv
@@ -378,7 +378,7 @@ module mkSelfInvIPipe(
 
     CCPipe#(
         wayNum, indexT, tagT, Msi, dirT, ownerT, otherT, repT, Line, pipeCmdT
-    ) pipe <- mkCCPipe(
+    ) pipe <- mkCCPipeSingleCycle(
         regToReadOnly(initDone), getIndex, tagMatch,
         updateByUpCs, updateByDownDir, updateRepInfo,
         infoRam, repRam, dataRam

--- a/src_Core/RISCY_OOO/coherence/src/SelfInvL1Pipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/SelfInvL1Pipe.bsv
@@ -401,7 +401,7 @@ module mkSelfInvL1Pipe(
 
     CCPipe#(
         wayNum, indexT, tagT, Msi, dirT, ownerT, otherT, repT, Line, pipeCmdT
-    ) pipe <- mkCCPipe(
+    ) pipe <- mkCCPipeSingleCycle(
         regToReadOnly(initDone), getIndex, tagMatch,
         updateByUpCs, updateByDownDir, updateRepInfo,
         infoRam, repRam, dataRam

--- a/src_Core/RISCY_OOO/coherence/src/SelfInvL1Pipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/SelfInvL1Pipe.bsv
@@ -262,7 +262,7 @@ module mkSelfInvL1Pipe(
     // rep RAM (dummy)
     RWBramCore#(indexT, repT) repRam <- mkRandRepRam;
     // data RAM
-    RWBramCore#(dataIndexT, Line) dataRam <- mkRWBramCore;
+    Vector#(wayNum, RWBramCore#(indexT, Line)) dataRam <- replicateM(mkRWBramCoreForwarded);
 
     // initialize RAM
     Reg#(Bool) initDone <- mkReg(False);

--- a/src_Core/RISCY_OOO/coherence/src/SelfInvLLPipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/SelfInvLLPipe.bsv
@@ -150,7 +150,7 @@ module mkSelfInvLLPipe(
     // RAMs
     Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam <- replicateM(mkRWBramCore);
     RWBramCore#(indexT, repT) repRam <- mkRandRepRam;
-    RWBramCore#(dataIndexT, Line) dataRam <- mkRWBramCore;
+    Vector#(wayNum, RWBramCore#(indexT, Line)) dataRam <- replicateM(mkRWBramCore);
     
     // initialize RAM
     Reg#(Bool) initDone <- mkReg(False);

--- a/src_Core/RISCY_OOO/coherence/src/SelfInvLLPipe.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/SelfInvLLPipe.bsv
@@ -150,7 +150,7 @@ module mkSelfInvLLPipe(
     // RAMs
     Vector#(wayNum, RWBramCore#(indexT, infoT)) infoRam <- replicateM(mkRWBramCore);
     RWBramCore#(indexT, repT) repRam <- mkRandRepRam;
-    Vector#(wayNum, RWBramCore#(indexT, Line)) dataRam <- replicateM(mkRWBramCore);
+    RWBramCore#(dataIndexT, Line) dataRam <- mkRWBramCore;
     
     // initialize RAM
     Reg#(Bool) initDone <- mkReg(False);

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -287,7 +287,7 @@ module mkFetchStage(FetchStage);
 
     // Pipeline Stage FIFOs
     Fifo#(1, Addr) translateAddress <- mkCFFifo;
-    Fifo#(4, Fetch1ToFetch2) fetch1toFetch2 <- mkCFFifo; // FIFO should match I$ latency
+    Fifo#(3, Fetch1ToFetch2) fetch1toFetch2 <- mkCFFifo; // FIFO should match I$ latency
     // These two fifos needs a capacity of 3 for full throughput if we fire only when we can enq on on channels.
     SupFifo#(SupSizeX2, 3, Fetch2ToDecode) f2d <- mkUGSupFifo; // Unguarded to prevent the static analyser from exploding.
     SupFifo#(SupSize, 3, FromFetchStage) out_fifo <- mkSupFifo;
@@ -438,8 +438,8 @@ module mkFetchStage(FetchStage);
 
             if (verbosity >= 2) begin
                 $display ("%d ----------------", cur_cycle);
-                $display ("%d Fetch1: TLB response pyhs_pc 0x%0h  cause ", cur_cycle, phys_pc, fshow (cause));
-                $display ("%d Fetch1: f2_tof3.enq: out ", cur_cycle, fshow (out));
+                $display ("%d Fetch1: translated pyhs_pc 0x%0h  cause ", cur_cycle, phys_pc, fshow (cause));
+                $display ("%d Fetch1: fetch1toFetch2.enq: out ", cur_cycle, fshow (out));
             end
             pc_reg[pc_fetch1_port] <= next_fetch_pc;
             if (verbose) $display("%d Fetch1: ", cur_cycle, fshow(out), " posLastSupX2: %d", posLastSupX2);

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -408,10 +408,7 @@ module mkFetchStage(FetchStage);
         TlbResp tr <- tlb_server.response.get;
         translateAddress.deq;
         // Check if, because of pipelining, we already have this vpn.
-        Bool found = False;
-        for (Integer i = 0; i < valueOf(PageBuffSize); i=i+1)
-            if (buffered_translation_virt_pc[i] matches tagged Valid .vpn &&& getVpn(translateAddress.first) == vpn)
-                found = True;
+        Bool found = elem(Valid(getVpn(translateAddress.first)), buffered_translation_virt_pc);
         if (!found) begin
             buffered_translation_virt_pc[buffered_translation_count] <= Valid(getVpn(translateAddress.first));
             buffered_translation_tlb_resp[buffered_translation_count] <= tr;
@@ -443,10 +440,7 @@ module mkFetchStage(FetchStage);
         Maybe#(Addr) pred_next_pc = pred_future_pc[posLastSupX2];
 
         // Search the last few translations to look for a match.
-        Maybe#(Bit#(TLog#(PageBuffSize))) m_buff_match_idx = Invalid;
-        for (Integer i = 0; i < valueOf(PageBuffSize); i=i+1)
-            if (buffered_translation_virt_pc[i] matches tagged Valid .vpn &&& getVpn(pc) == vpn)
-                m_buff_match_idx = tagged Valid fromInteger(i);
+        Maybe#(UInt#(TLog#(PageBuffSize))) m_buff_match_idx = findElem(Valid(getVpn(pc)), buffered_translation_virt_pc);
         if (m_buff_match_idx matches tagged Valid .buff_match_idx) begin
             let next_fetch_pc = fromMaybe(pc + (2 * (zeroExtend(posLastSupX2) + 1)), pred_next_pc);
             let pc_idxs <- pcBlocks.insertAndReserve(truncateLSB(pc), truncateLSB(next_fetch_pc));

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -290,7 +290,7 @@ module mkFetchStage(FetchStage);
     Reg#(Epoch) f_main_epoch <- mkReg(0); // fetch estimate of main epoch
 
     // Pipeline Stage FIFOs
-    Fifo#(2, Fetch1ToFetch2) f12f2 <- mkCFFifo;
+    Fifo#(2, Fetch1ToFetch2) f12f2 <- mkBypassFifo;
     Fifo#(4, Fetch2ToFetch3) f22f3 <- mkCFFifo; // FIFO should match I$ latency
     // These two fifos needs a capacity of 3 for full throughput if we fire only when we can enq on on channels.
     SupFifo#(SupSizeX2, 3, Fetch3ToDecode) f32d <- mkUGSupFifo; // Unguarded to prevent the static analyser from exploding.

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -287,7 +287,7 @@ module mkFetchStage(FetchStage);
 
     // Pipeline Stage FIFOs
     Fifo#(1, Addr) translateAddress <- mkCFFifo;
-    Fifo#(3, Fetch1ToFetch2) fetch1toFetch2 <- mkCFFifo; // FIFO should match I$ latency
+    Fifo#(2, Fetch1ToFetch2) fetch1toFetch2 <- mkCFFifo; // FIFO should match I$ latency
     // These two fifos needs a capacity of 3 for full throughput if we fire only when we can enq on all channels.
     SupFifo#(SupSizeX2, 3, Fetch2ToDecode) f2d <- mkUGSupFifo; // Unguarded to prevent the static analyser from exploding.
     SupFifo#(SupSize, 3, FromFetchStage) out_fifo <- mkSupFifo;

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -129,19 +129,11 @@ typedef struct {
     PcCompressed pc;
     Bit#(TLog#(SupSizeX2)) inst_frags_fetched;
     Maybe#(PcCompressed) pred_next_pc;
-    Bool decode_epoch;
-    Epoch main_epoch;
-} Fetch1ToFetch2 deriving(Bits, Eq, FShow);
-
-typedef struct {
-    PcCompressed pc;
-    Bit#(TLog#(SupSizeX2)) inst_frags_fetched;
-    Maybe#(PcCompressed) pred_next_pc;
     Maybe#(Exception) cause;
     Bool access_mmio; // inst fetch from MMIO
     Bool decode_epoch;
     Epoch main_epoch;
-} Fetch2ToFetch3 deriving(Bits, Eq, FShow);
+} Fetch1ToFetch2 deriving(Bits, Eq, FShow);
 
 typedef struct {
     PcCompressed pc;
@@ -150,7 +142,7 @@ typedef struct {
     Bit#(16) inst_frag;
     Bool decode_epoch;
     Epoch main_epoch;
-} Fetch3ToDecode deriving(Bits, Eq, FShow);
+} Fetch2ToDecode deriving(Bits, Eq, FShow);
 
 // Used purely internally in doDecode.
 typedef struct {
@@ -165,10 +157,10 @@ typedef struct {
   Maybe#(Exception) cause;
   Bool cause_second_half;
   Bool mispred_first_half;
-} InstrFromFetch3 deriving(Bits, Eq, FShow);
+} InstrFromFetch2 deriving(Bits, Eq, FShow);
 
-function InstrFromFetch3 fetch3_2_instC(Fetch3ToDecode in, Instruction inst, Bit#(32) orig_inst) =
-   InstrFromFetch3 {
+function InstrFromFetch2 fetch2_2_instC(Fetch2ToDecode in, Instruction inst, Bit#(32) orig_inst) =
+   InstrFromFetch2 {
       pc: in.pc,
       // This assumes we will call this function on the last fragment of any instruction.
       ppc: fromMaybe(PcCompressed{lsb: in.pc.lsb + 2,
@@ -185,9 +177,9 @@ function InstrFromFetch3 fetch3_2_instC(Fetch3ToDecode in, Instruction inst, Bit
       mispred_first_half: False
    };
 
-function InstrFromFetch3 fetch3s_2_inst(Fetch3ToDecode inHi, Fetch3ToDecode inLo);
+function InstrFromFetch2 fetch2s_2_inst(Fetch2ToDecode inHi, Fetch2ToDecode inLo);
    Instruction inst = {inHi.inst_frag, inLo.inst_frag};
-   InstrFromFetch3 ret = fetch3_2_instC(inHi, inst, inst);
+   InstrFromFetch2 ret = fetch2_2_instC(inHi, inst, inst);
    if (isValid(inLo.cause)) ret.cause = inLo.cause;
    else if (isValid(inHi.cause)) ret.cause_second_half = True;
    ret.inst_kind = Inst_32b;
@@ -255,8 +247,8 @@ deriving (Bits, Eq, FShow);
 
 (* synthesize *)
 module mkFetchStage(FetchStage);
-    // rule ordering: Fetch1 (BTB+TLB) < Fetch3 (decode & dir pred) < redirect method
-    // Fetch1 < Fetch3 to avoid bypassing path on PC and epochs
+    // rule ordering: Fetch1 (BTB+TLB) < Fetch2 (decode & dir pred) < redirect method
+    // Fetch1 < Fetch2 to avoid bypassing path on PC and epochs
 
     Bool verbose = True;
     Integer verbosity = 2;
@@ -278,7 +270,7 @@ module mkFetchStage(FetchStage);
     Ehr#(5, Addr) pc_reg <- mkEhr(0);
     Integer pc_fetch1_port = 0;
     Integer pc_decode_port = 1;
-    Integer pc_fetch3_port = 2;
+    Integer pc_fetch2_port = 2;
     Integer pc_redirect_port = 3;
     Integer pc_final_port = 4;
     // To track the next expected PC in Decode for early lookups for prediction.
@@ -294,10 +286,10 @@ module mkFetchStage(FetchStage);
     Reg#(Epoch) f_main_epoch <- mkReg(0); // fetch estimate of main epoch
 
     // Pipeline Stage FIFOs
-    Fifo#(4, Addr) translateAddress <- mkCFFifo;
-    Fifo#(4, Fetch2ToFetch3) f22f3 <- mkCFFifo; // FIFO should match I$ latency
+    Fifo#(1, Addr) translateAddress <- mkCFFifo;
+    Fifo#(4, Fetch1ToFetch2) fetch1toFetch2 <- mkCFFifo; // FIFO should match I$ latency
     // These two fifos needs a capacity of 3 for full throughput if we fire only when we can enq on on channels.
-    SupFifo#(SupSizeX2, 3, Fetch3ToDecode) f32d <- mkUGSupFifo; // Unguarded to prevent the static analyser from exploding.
+    SupFifo#(SupSizeX2, 3, Fetch2ToDecode) f2d <- mkUGSupFifo; // Unguarded to prevent the static analyser from exploding.
     SupFifo#(SupSize, 3, FromFetchStage) out_fifo <- mkSupFifo;
        // Can the fifo size be smaller?
 
@@ -352,49 +344,6 @@ module mkFetchStage(FetchStage);
         nextAddrPred.put_pc(pc_reg[pc_final_port]);
     endrule
 
-    function Action start_imem_lookup(Fetch1ToFetch2 in, TlbResp tr) = action
-        match {.buffered_phys_pc, .cause} = tr;
-        Addr phys_pc = unpack({buffered_phys_pc[63:12],in.pc.lsb[11:0]});
-        // Access main mem or boot rom if no TLB exception
-        Bool access_mmio = False;
-        if (!isValid(cause)) begin
-            case(mmio.getFetchTarget(phys_pc))
-                MainMem: begin
-                    // Send ICache request
-                    mem_server.request.put(phys_pc);
-                end
-                IODevice: begin
-                    // Send MMIO req. Luckily boot rom is also aligned with
-                    // cache line size, so all nbSup+1 insts can be fetched
-                    // from boot rom. It won't happen that insts fetched from
-                    // boot rom is less than requested.
-                    mmio.bootRomReq(phys_pc, in.inst_frags_fetched);
-                    access_mmio = True;
-                end
-                default: begin
-                    // Access fault
-                    cause = Valid (InstAccessFault);
-                end
-            endcase
-        end
-
-        let out = Fetch2ToFetch3 {
-            pc: in.pc,
-            inst_frags_fetched: in.inst_frags_fetched,
-            pred_next_pc: in.pred_next_pc,
-            cause: cause,
-            access_mmio: access_mmio,
-            decode_epoch: in.decode_epoch,
-            main_epoch: in.main_epoch };
-        f22f3.enq(out);
-
-        if (verbosity >= 2) begin
-            $display ("%d ----------------", cur_cycle);
-            $display ("%d Fetch1: TLB response pyhs_pc 0x%0h  cause ", cur_cycle, phys_pc, fshow (cause));
-            $display ("%d Fetch1: f2_tof3.enq: out ", cur_cycle, fshow (out));
-        end
-    endaction;
-
     Reg#(Vector#(PageBuffSize,Maybe#(Vpn))) buffered_translation_virt_pc <- mkReg(replicate(Invalid));
     Reg#(Vector#(PageBuffSize,TlbResp)) buffered_translation_tlb_resp <- mkRegU;
     Reg#(Bit#(TLog#(PageBuffSize))) buffered_translation_count <- mkRegU;
@@ -403,6 +352,8 @@ module mkFetchStage(FetchStage);
         buffered_translation_virt_pc <= replicate(Invalid);
     endrule
 
+    // getTlbResp catches a iTLB translation and writes it into translation
+    // buffer. If there is an active iTlb flush, clear the buffer.
     rule getTlbResp;
         // Get TLB response
         TlbResp tr <- tlb_server.response.get;
@@ -419,10 +370,11 @@ module mkFetchStage(FetchStage);
         if (verbosity >= 2) $display ("%d Fetch Translate: pc: %x, ", cur_cycle, translateAddress.first, fshow (tr));
     endrule
 
-    // We don't send req to TLB when waiting for redirect or TLB flush. Since
-    // there is no FIFO between doFetch1 and TLB, when OOO commit stage wait
-    // TLB idle to change VM CSR / signal flush TLB, there is no wrong path
-    // request afterwards to race with the system code that manage paget table.
+    // doFetch1 pulls a prediction out of the BTB and attempts to translate it
+    // from a small buffer (~2) of recent TLB translations.
+    // If the necessary translation is not in the buffer, doFetch1 submits a TLB
+    // lookup request and then retrys until getTlbResp has populated the buffer
+    // and the lookup succeeds.
     rule doFetch1(started && !waitForRedirect[0] && !waitForFlush[0]);
         let pc = pc_reg[pc_fetch1_port];
 
@@ -448,14 +400,47 @@ module mkFetchStage(FetchStage);
             let pc_idxs <- pcBlocks.insertAndReserve(truncateLSB(pc), truncateLSB(next_fetch_pc));
             PcIdx pc_idx = pc_idxs.inserted;
             PcIdx ppc_idx = pc_idxs.reserved;
+            match {.buffered_phys_pc, .cause} = buffered_translation_tlb_resp[buff_match_idx];
+            Addr phys_pc = unpack({buffered_phys_pc[63:12],pc[11:0]});
+            // Access main mem or boot rom if no TLB exception
+            Bool access_mmio = False;
+            if (!isValid(cause)) begin
+                case(mmio.getFetchTarget(phys_pc))
+                    MainMem: begin
+                        // Send ICache request
+                        mem_server.request.put(phys_pc);
+                    end
+                    IODevice: begin
+                        // Send MMIO req. Luckily boot rom is also aligned with
+                        // cache line size, so all nbSup+1 insts can be fetched
+                        // from boot rom. It won't happen that insts fetched from
+                        // boot rom is less than requested.
+                        mmio.bootRomReq(phys_pc, posLastSupX2);
+                        access_mmio = True;
+                    end
+                    default: begin
+                        // Access fault
+                        cause = Valid (InstAccessFault);
+                    end
+                endcase
+            end
+
             let out = Fetch1ToFetch2 {
                 pc: compressPc(pc_idx, pc),
                 inst_frags_fetched: posLastSupX2,
                 pred_next_pc: isValid(pred_next_pc) ?
                     Valid(compressPc(ppc_idx, validValue(pred_next_pc))) : Invalid,
+                cause: cause,
+                access_mmio: access_mmio,
                 decode_epoch: decode_epoch[0],
-                main_epoch: f_main_epoch};
-            start_imem_lookup(out, buffered_translation_tlb_resp[buff_match_idx]);
+                main_epoch: f_main_epoch };
+            fetch1toFetch2.enq(out);
+
+            if (verbosity >= 2) begin
+                $display ("%d ----------------", cur_cycle);
+                $display ("%d Fetch1: TLB response pyhs_pc 0x%0h  cause ", cur_cycle, phys_pc, fshow (cause));
+                $display ("%d Fetch1: f2_tof3.enq: out ", cur_cycle, fshow (out));
+            end
             pc_reg[pc_fetch1_port] <= next_fetch_pc;
             if (verbose) $display("%d Fetch1: ", cur_cycle, fshow(out), " posLastSupX2: %d", posLastSupX2);
         end else begin
@@ -468,85 +453,85 @@ module mkFetchStage(FetchStage);
 
     // Break out of i$
     Vector#(SupSizeX2,Integer) indexes = genVector;
-    function Bool f32d_lane_notFull(Integer i) = f32d.enqS[i].canEnq;
-    rule doFetch3(all(f32d_lane_notFull, indexes));
-        let fetch3In = f22f3.first;
+    function Bool f2d_lane_notFull(Integer i) = f2d.enqS[i].canEnq;
+    rule doFetch2(all(f2d_lane_notFull, indexes));
+        let fetch2In = fetch1toFetch2.first;
         if (verbosity >= 2) begin
-            if (f22f3.notEmpty)
-                $display("%d Fetch3: fetch3In: ", cur_cycle, fshow (fetch3In));
+            if (fetch1toFetch2.notEmpty)
+                $display("%d Fetch2: fetch2In: ", cur_cycle, fshow (fetch2In));
             else
-                $display("%d Fetch3: Nothing else from Fetch2", cur_cycle);
+                $display("%d Fetch2: Nothing else from Fetch1", cur_cycle);
         end
 
-        let drop_f22f3 =    f22f3.notEmpty
-                         && (   fetch3In.main_epoch != f_main_epoch
-                             || fetch3In.decode_epoch != decode_epoch[1]);
+        let drop_fetch1toFetch2 =    fetch1toFetch2.notEmpty
+                         && (   fetch2In.main_epoch != f_main_epoch
+                             || fetch2In.decode_epoch != decode_epoch[1]);
 
-        let parse_f22f3 = !drop_f22f3;
+        let parse_fetch1toFetch2 = !drop_fetch1toFetch2;
 
         // Get ICache/MMIO response if no exception
         // In case of exception, we still need to process at least inst_data[0]
         // (it will be turned to an exception later), so inst_data[0] must be
         // valid.
         Vector#(SupSizeX2,Maybe#(Instruction16)) inst_d = replicate(tagged Valid (0));
-        f22f3.deq();
-        if (!isValid(fetch3In.cause)) begin
-           if(fetch3In.access_mmio) begin
+        fetch1toFetch2.deq();
+        if (!isValid(fetch2In.cause)) begin
+           if(fetch2In.access_mmio) begin
               inst_d <- mmio.bootRomResp;
-              if(verbose) $display("get answer from MMIO 0x%0x", decompressPc(fetch3In.pc), " ", fshow(inst_d));
+              if(verbose) $display("get answer from MMIO 0x%0x", decompressPc(fetch2In.pc), " ", fshow(inst_d));
            end
            else begin
-              if(verbose) $display("get answer from memory 0x%0x", decompressPc(fetch3In.pc));
+              if(verbose) $display("get answer from memory 0x%0x", decompressPc(fetch2In.pc));
                  inst_d <- mem_server.response.get;
            end
         end
 
-        for (Integer i = 0; i < valueOf(SupSizeX2) && fromInteger(i) <= fetch3In.inst_frags_fetched; i = i + 1) begin
-           PcCompressed pc = fetch3In.pc;
+        for (Integer i = 0; i < valueOf(SupSizeX2) && fromInteger(i) <= fetch2In.inst_frags_fetched; i = i + 1) begin
+           PcCompressed pc = fetch2In.pc;
            pc.lsb = pc.lsb + (2 * fromInteger(i));
-           f32d.enqS[i].enq (Fetch3ToDecode {
+           f2d.enqS[i].enq (Fetch2ToDecode {
                pc: pc,
-               ppc: (fromInteger(i)==fetch3In.inst_frags_fetched) ? fetch3In.pred_next_pc : Invalid,
+               ppc: (fromInteger(i)==fetch2In.inst_frags_fetched) ? fetch2In.pred_next_pc : Invalid,
                inst_frag: validValue(inst_d[i]),
-               cause: fetch3In.cause,
-               decode_epoch: fetch3In.decode_epoch,
-               main_epoch: fetch3In.main_epoch
+               cause: fetch2In.cause,
+               decode_epoch: fetch2In.decode_epoch,
+               main_epoch: fetch2In.main_epoch
            });
         end
-    endrule: doFetch3
+    endrule: doFetch2
 
-   function Bool isCurrent(Fetch3ToDecode in) = (in.main_epoch == f_main_epoch && in.decode_epoch == decode_epoch[0]);
+   function Bool isCurrent(Fetch2ToDecode in) = (in.main_epoch == f_main_epoch && in.decode_epoch == decode_epoch[0]);
 
-   rule doDecodeFlush(f32d.deqS[0].canDeq && !isCurrent(f32d.deqS[0].first));
+   rule doDecodeFlush(f2d.deqS[0].canDeq && !isCurrent(f2d.deqS[0].first));
       for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1)
-         if (f32d.deqS[i].canDeq &&& !isCurrent(f32d.deqS[i].first)) begin
-            pcBlocks.rPort[i].remove(f32d.deqS[i].first.pc.idx);
-            f32d.deqS[i].deq;
+         if (f2d.deqS[i].canDeq &&& !isCurrent(f2d.deqS[i].first)) begin
+            pcBlocks.rPort[i].remove(f2d.deqS[i].first.pc.idx);
+            f2d.deqS[i].deq;
          end
    endrule: doDecodeFlush
 
-   rule doDecode(f32d.deqS[0].canDeq && isCurrent(f32d.deqS[0].first));
-      Vector#(SupSize, Maybe#(InstrFromFetch3)) decodeIn = replicate(Invalid);
+   rule doDecode(f2d.deqS[0].canDeq && isCurrent(f2d.deqS[0].first));
+      Vector#(SupSize, Maybe#(InstrFromFetch2)) decodeIn = replicate(Invalid);
       // Express the incoming fragments as a vector of maybes.
-      Vector#(SupSizeX2, Maybe#(Fetch3ToDecode)) frags;
+      Vector#(SupSizeX2, Maybe#(Fetch2ToDecode)) frags;
       for (Integer i = 0; i < valueOf(SupSizeX2); i = i + 1)
-         frags[i] = (f32d.deqS[i].canDeq) ? Valid (f32d.deqS[i].first) : Invalid;
-      // Pick as up to SupSize instructions from the f32d SupFifo.
+         frags[i] = (f2d.deqS[i].canDeq) ? Valid (f2d.deqS[i].first) : Invalid;
+      // Pick as up to SupSize instructions from the f2d SupFifo.
       // Stop picking when we have SupSize instructions or when we have exhausted the ports on the instruction fragment FIFO.
       Maybe#(Bit#(TLog#(SupSizeX2))) m_used_frag_count = Invalid;
       Bit#(TLog#(SupSize)) pick_count = 0;
       Bool prev_frag_available = False;
       for (Integer i = 0; i < valueOf(SupSizeX2) && !isValid(decodeIn[valueOf(SupSize) - 1]); i = i + 1) begin
-         Maybe#(InstrFromFetch3) new_pick = Invalid;
+         Maybe#(InstrFromFetch2) new_pick = Invalid;
          if (frags[i] matches tagged Valid .frag) begin
-            Fetch3ToDecode prev_frag = (i != 0) ? validValue(frags[i-1]) : ?;
+            Fetch2ToDecode prev_frag = (i != 0) ? validValue(frags[i-1]) : ?;
             if (prev_frag_available &&& !is_16b_inst(prev_frag.inst_frag)) begin // 2nd half of 32-bit instruction
-               new_pick = tagged Valid fetch3s_2_inst(frag, prev_frag);
+               new_pick = tagged Valid fetch2s_2_inst(frag, prev_frag);
                if (!validValue(new_pick).mispred_first_half) begin
                   doAssert(decompressPc(prev_frag.pc)+2 == decompressPc(frag.pc), "Attached fragments with non-contigious PCs");
                end
             end else if (is_16b_inst(frag.inst_frag) || isValid(frag.cause)) begin // 16-bit instruction
-               new_pick = tagged Valid fetch3_2_instC(frag,
+               new_pick = tagged Valid fetch2_2_instC(frag,
                                                       fv_decode_C (misa, misa_mxl_64, frag.inst_frag),
                                                       zeroExtend(frag.inst_frag));
             end
@@ -561,7 +546,7 @@ module mkFetchStage(FetchStage);
          end else prev_frag_available = isValid(frags[i]);
       end
       if (m_used_frag_count matches tagged Valid .used_frag_count) begin
-         for (Integer i = 0; i < valueOf(SupSizeX2) && fromInteger(i) <= used_frag_count; i = i + 1) f32d.deqS[i].deq;
+         for (Integer i = 0; i < valueOf(SupSizeX2) && fromInteger(i) <= used_frag_count; i = i + 1) f2d.deqS[i].deq;
          if (verbose)
             $display("%d Decode: dequed %d instruction fragments", cur_cycle, used_frag_count);
       end
@@ -764,8 +749,8 @@ module mkFetchStage(FetchStage);
     // (2) all internal FIFOs are empty (the output sup fifo needs not to be
     // empty, but why leave this security hole)
     Bool empty_for_flush = waitForFlush[0] &&
-                           !translateAddress.notEmpty && !f22f3.notEmpty &&
-                           f32d.internalEmpty && out_fifo.internalEmpty;
+                           !translateAddress.notEmpty && !fetch1toFetch2.notEmpty &&
+                           f2d.internalEmpty && out_fifo.internalEmpty;
 
     interface Vector pipelines = out_fifo.deqS;
     interface iTlbIfc = iTlb;

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -288,7 +288,7 @@ module mkFetchStage(FetchStage);
     // Pipeline Stage FIFOs
     Fifo#(1, Addr) translateAddress <- mkCFFifo;
     Fifo#(3, Fetch1ToFetch2) fetch1toFetch2 <- mkCFFifo; // FIFO should match I$ latency
-    // These two fifos needs a capacity of 3 for full throughput if we fire only when we can enq on on channels.
+    // These two fifos needs a capacity of 3 for full throughput if we fire only when we can enq on all channels.
     SupFifo#(SupSizeX2, 3, Fetch2ToDecode) f2d <- mkUGSupFifo; // Unguarded to prevent the static analyser from exploding.
     SupFifo#(SupSize, 3, FromFetchStage) out_fifo <- mkSupFifo;
        // Can the fifo size be smaller?

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -403,17 +403,19 @@ module mkFetchStage(FetchStage);
         buffered_translation_virt_pc <= replicate(Invalid);
     endrule
 
-    rule getTlbResp(iTlb.flush_done);
+    rule getTlbResp;
         // Get TLB response
         TlbResp tr <- tlb_server.response.get;
         translateAddress.deq;
-        // Check if, because of pipelining, we already have this vpn.
-        Bool found = elem(Valid(getVpn(translateAddress.first)), buffered_translation_virt_pc);
-        if (!found) begin
-            buffered_translation_virt_pc[buffered_translation_count] <= Valid(getVpn(translateAddress.first));
-            buffered_translation_tlb_resp[buffered_translation_count] <= tr;
-            buffered_translation_count <= buffered_translation_count + 1;
-        end
+        if (iTlb.flush_done) begin
+            // Check if, because of pipelining, we already have this vpn.
+            Bool found = elem(Valid(getVpn(translateAddress.first)), buffered_translation_virt_pc);
+            if (!found) begin
+                buffered_translation_virt_pc[buffered_translation_count] <= Valid(getVpn(translateAddress.first));
+                buffered_translation_tlb_resp[buffered_translation_count] <= tr;
+                buffered_translation_count <= buffered_translation_count + 1;
+            end
+        end else buffered_translation_virt_pc <= replicate(Invalid);
         if (verbosity >= 2) $display ("%d Fetch Translate: pc: %x, ", cur_cycle, translateAddress.first, fshow (tr));
     endrule
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -250,8 +250,8 @@ module mkFetchStage(FetchStage);
     // rule ordering: Fetch1 (BTB+TLB) < Fetch2 (decode & dir pred) < redirect method
     // Fetch1 < Fetch2 to avoid bypassing path on PC and epochs
 
-    Bool verbose = True;
-    Integer verbosity = 2;
+    Bool verbose = False;
+    Integer verbosity = 0;
 
     // Basic State Elements
     Reg#(Bool) started <- mkReg(False);

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/MemExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/MemExePipeline.bsv
@@ -117,17 +117,17 @@ typedef struct {
 
 //SpecFifo#(2,IncorrectSpec,1,1) incorrectSpec_ff <- mkSpecFifoCF(True);
 // synthesized pipeline fifos
-//typedef SpecFifo_SB_deq_enq_C_deq_enq#(1, MemDispatchToRegRead) MemDispToRegFifo;
+typedef SpecFifo_SB_deq_enq_C_deq_enq#(1, MemDispatchToRegRead) MemDispToRegFifo;
 (* synthesize *)
-module mkMemDispToRegFifo(SpecFifo#(2,MemDispatchToRegRead,1,1));
-    let m <- mkSpecFifoCF2(True);
+module mkMemDispToRegFifo(MemDispToRegFifo);
+    let m <- mkSpecFifo_SB_deq_enq_C_deq_enq(False);
     return m;
 endmodule
 
-//typedef SpecFifo_SB_deq_enq_C_deq_enq#(1, MemRegReadToExe) MemRegToExeFifo;
+typedef SpecFifo_SB_deq_enq_C_deq_enq#(1, MemRegReadToExe) MemRegToExeFifo;
 (* synthesize *)
-module mkMemRegToExeFifo(SpecFifo#(2,MemRegReadToExe,1,1));
-    let m <- mkSpecFifoCF2(True);
+module mkMemRegToExeFifo(MemRegToExeFifo);
+    let m <- mkSpecFifo_SB_deq_enq_C_deq_enq(False);
     return m;
 endmodule
 
@@ -620,7 +620,7 @@ module mkMemExePipeline#(MemExeInput inIfc)(MemExePipeline);
         // search LSQ
         LSQIssueLdResult issRes <- lsq.issueLd(info.tag, info.paddr, info.shiftedBE, sbRes);
         if(verbose) begin
-            $display("[doIssueLd] fromIssueQ: ", fshow(fromIssueQ), " ; ",
+            $display("%t : [doIssueLd] fromIssueQ: ", $time, fshow(fromIssueQ), " ; ",
                      fshow(info), " ; ", fshow(sbRes), " ; ", fshow(issRes));
         end
         // summarize

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/MemExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/MemExePipeline.bsv
@@ -115,18 +115,19 @@ typedef struct {
     Data shiftedData;
 } WaitStResp deriving(Bits, Eq, FShow);
 
+//SpecFifo#(2,IncorrectSpec,1,1) incorrectSpec_ff <- mkSpecFifoCF(True);
 // synthesized pipeline fifos
-typedef SpecFifo_SB_deq_enq_C_deq_enq#(1, MemDispatchToRegRead) MemDispToRegFifo;
+//typedef SpecFifo_SB_deq_enq_C_deq_enq#(1, MemDispatchToRegRead) MemDispToRegFifo;
 (* synthesize *)
-module mkMemDispToRegFifo(MemDispToRegFifo);
-    let m <- mkSpecFifo_SB_deq_enq_C_deq_enq(False);
+module mkMemDispToRegFifo(SpecFifo#(2,MemDispatchToRegRead,1,1));
+    let m <- mkSpecFifoCF2(True);
     return m;
 endmodule
 
-typedef SpecFifo_SB_deq_enq_C_deq_enq#(1, MemRegReadToExe) MemRegToExeFifo;
+//typedef SpecFifo_SB_deq_enq_C_deq_enq#(1, MemRegReadToExe) MemRegToExeFifo;
 (* synthesize *)
-module mkMemRegToExeFifo(MemRegToExeFifo);
-    let m <- mkSpecFifo_SB_deq_enq_C_deq_enq(False);
+module mkMemRegToExeFifo(SpecFifo#(2,MemRegReadToExe,1,1));
+    let m <- mkSpecFifoCF2(True);
     return m;
 endmodule
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/MemExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/MemExePipeline.bsv
@@ -665,8 +665,7 @@ module mkMemExePipeline#(MemExeInput inIfc)(MemExePipeline);
 
     rule doIssueLdFromIssueQ;
         // get issue entry from LSQ
-        LSQIssueLdInfo info <- lsq.getIssueLd;
-        doIssueLd(info, True);
+        doIssueLd(lsq.getIssueLd, True);
     endrule
 
     // we have ordered setRegReadyAggr_forward < setRegReadyAggr_mem to make

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/ProcConfig.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/ProcConfig.bsv
@@ -94,7 +94,7 @@
 
     // L1
     `define LOG_L1_LINES 8 // 16KB
-    `define LOG_L1_WAYS 3 // 8 ways
+    `define LOG_L1_WAYS 2 // 4 ways
 
     // LLC
     `define LOG_LLC_LINES 12 // 256KB
@@ -106,7 +106,7 @@
 
     // L1
     `define LOG_L1_LINES 9 // 32KB
-    `define LOG_L1_WAYS 3 // 8 ways
+    `define LOG_L1_WAYS 2 // 4 ways
 
     // LLC
     `define LOG_LLC_LINES 14 // 1MB

--- a/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
@@ -245,6 +245,8 @@ module mkITlb(ITlb::ITlb);
         no_pending_wire <= !isValid(miss);
     endrule
 
+    Reg#(Bool) vm_info_change <- mkReg(False);
+
     method Action flush if(!needFlush);
         needFlush <= True;
         waitFlushP <= False;
@@ -253,9 +255,10 @@ module mkITlb(ITlb::ITlb);
         // (2) flush truly starts when there is no pending req
     endmethod
 
-    method Bool flush_done = !needFlush;
+    method Bool flush_done = !needFlush && !vm_info_change;
 
     method Action updateVMInfo(VMInfo vm);
+        if (vm_info != vm) vm_info_change <= True;
         vm_info <= vm;
     endmethod
 

--- a/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
@@ -114,7 +114,7 @@ module mkITlb(ITlb::ITlb);
     Reg#(Bool) waitFlushP <- mkReg(False);
 
     // resp FIFO to proc
-    Fifo#(2, TlbResp) hitQ <- mkBypassFifo;
+    Fifo#(2, TlbResp) hitQ <- mkCFFifo;
 
     // current processor VM information
     Reg#(VMInfo) vm_info <- mkReg(defaultValue);
@@ -296,7 +296,7 @@ module mkITlb(ITlb::ITlb);
                 if (False) begin
                     noAction;
                 end
-
+`endif
                 if (vm_info.sv39) begin
                     let vpn = getVpn(vaddr);
                     let trans_result = tlb.translate(vpn, vm_info.asid);

--- a/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
@@ -43,6 +43,7 @@ import ProcTypes::*;
 import TlbTypes::*;
 import Performance::*;
 import FullAssocTlb::*;
+import DReg::*;
 import ConfigReg::*;
 import Fifos::*;
 import Cntrs::*;
@@ -245,7 +246,7 @@ module mkITlb(ITlb::ITlb);
         no_pending_wire <= !isValid(miss);
     endrule
 
-    Reg#(Bool) vm_info_change <- mkReg(False);
+    Reg#(Bool) vm_info_change <- mkDReg(False);
 
     method Action flush if(!needFlush);
         needFlush <= True;

--- a/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
@@ -114,7 +114,7 @@ module mkITlb(ITlb::ITlb);
     Reg#(Bool) waitFlushP <- mkReg(False);
 
     // resp FIFO to proc
-    Fifo#(2, TlbResp) hitQ <- mkCFFifo;
+    Fifo#(2, TlbResp) hitQ <- mkBypassFifo;
 
     // current processor VM information
     Reg#(VMInfo) vm_info <- mkReg(defaultValue);
@@ -296,8 +296,8 @@ module mkITlb(ITlb::ITlb);
                 if (False) begin
                     noAction;
                 end
-`endif
-                else if (vm_info.sv39) begin
+
+                if (vm_info.sv39) begin
                     let vpn = getVpn(vaddr);
                     let trans_result = tlb.translate(vpn, vm_info.asid);
                     if (!validVirtualAddress(vaddr)) hitQ.enq(tuple2(?, Valid (InstPageFault)));

--- a/src_Core/RISCY_OOO/procs/lib/Map.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Map.bsv
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2021 Jonathan Woodruff
 //
 // All rights reserved.
@@ -55,12 +54,13 @@ typedef struct {
 // the value stored in the map, and the associativity of the storage.
 interface Map#(type ky, type ix, type vl, numeric type as);
     method Action update(MapKeyIndex#(ky,ix) key, vl value);
+    method Action updateWithFunc(MapKeyIndex#(ky,ix) ki, vl value, function vl up(vl old_v, vl new_v), Bool insert);
     method Maybe#(vl) lookup(MapKeyIndex#(ky,ix) lookup_key);
     method Action clear;
     method Bool clearDone;
 endinterface
 
-module mkMapLossy(Map#(ky,ix,vl,as)) provisos (
+module mkMapLossy#(vl default_value)(Map#(ky,ix,vl,as)) provisos (
 Bits#(ky,ky_sz), Bits#(vl,vl_sz), Eq#(ky), Arith#(ky),
 Bounded#(ix), Literal#(ix), Bits#(ix, ix_sz),
 Bitwise#(ix), Eq#(ix), Arith#(ix));
@@ -73,21 +73,37 @@ Bitwise#(ix), Eq#(ix), Arith#(ix));
     Reg#(ix) clearCount <- mkReg(0);
     PulseWire didUpdate <- mkPulseWire;
     rule doClear(clearReg && !didUpdate);
-        for (Integer i = 0; i < a; i = i + 1) mem[i].upd(clearCount, default_value);
+        for (Integer i = 0; i < a; i = i + 1) mem[i].upd(clearCount, MapKeyValue{key: ?, value: default_value});
         clearCount <= clearCount + 1;
         if (clearCount == ~0) clearReg <= False;
     endrule
 
-    method Action update(MapKeyIndex#(ky,ix) ki, vl value);
+    function Action doUpdate(MapKeyIndex#(ky,ix) ki, vl value, function vl up(vl old_v, vl new_v), Bool insert);
+    action
+        Bool found = False;
         Bit#(TLog#(as)) way = wayNext;
+        vl old_value = default_value;
         if (a > 1) begin
-          for (Integer i = 0; i < a; i = i + 1)
-              if (mem[i].sub(ki.index).key == ki.key) way = fromInteger(i);
+            for (Integer i = 0; i < a; i = i + 1) begin
+                MapKeyValue#(ky,vl) entry = mem[i].sub(ki.index);
+                if (entry.key == ki.key) begin
+                    found = True;
+                    way = fromInteger(i);
+                    old_value = entry.value;
+                end
+            end
         end
-        mem[way].upd(ki.index, MapKeyValue{key: ki.key, value: value});
+        if (found || insert) mem[way].upd(ki.index, MapKeyValue{key: ki.key, value: up(old_value, value)});
         wayNext <= (wayNext == fromInteger(a-1)) ? 0: wayNext + 1;
         didUpdate.send;
-    endmethod
+    endaction
+    endfunction
+
+    function vl returnNew(vl old_v, vl new_v) = new_v;
+    method Action update(MapKeyIndex#(ky,ix) ki, vl value) = doUpdate(ki, value, returnNew, True);
+    method Action updateWithFunc(MapKeyIndex#(ky,ix) ki, vl value, function vl up(vl old_v, vl new_v), Bool insert) =
+        doUpdate(ki, value, up, insert);
+
     method Maybe#(vl) lookup(MapKeyIndex#(ky,ix) lu);
         Maybe#(vl) ret = Invalid;
         for (Integer i = 0; i < a; i = i + 1) begin
@@ -124,7 +140,11 @@ Bitwise#(ix), Eq#(ix), Arith#(ix), PrimIndex#(ix, a__));
     Reg#(ix) clearCount <- mkReg(0);
     (* fire_when_enabled, no_implicit_conditions *)
     rule updateCanon;
-        if (updateFresh) begin
+        if (clearReg) begin
+            for (Integer i = 0; i < a; i = i + 1) mem[i].wrReq(clearCount, unpack(0));
+            clearCount <= clearCount + 1;
+            if (clearCount == ~0) clearReg <= False;
+        end else if (updateFresh) begin
             let u = updateReg;
             Bit#(TLog#(as)) way = wayNext;
             for (Integer i = 0; i < a; i = i + 1)
@@ -135,10 +155,6 @@ Bitwise#(ix), Eq#(ix), Arith#(ix), PrimIndex#(ix, a__));
             mem[way].wrReq(u.index, MapKeyValue{key: u.key, value: u.value});
             updateKeys[way].wrReq(u.index, u.key);
             wayNext <= (wayNext == fromInteger(a-1)) ? 0 : (wayNext + 1);
-        end else if (clearReg) begin
-            for (Integer i = 0; i < a; i = i + 1) mem[i].wrReq(clearCount, unpack(0));
-            clearCount <= clearCount + 1;
-            if (clearCount == ~0) clearReg <= False;
         end
     endrule
 

--- a/src_Core/RISCY_OOO/procs/lib/Map.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Map.bsv
@@ -73,7 +73,7 @@ Bitwise#(ix), Eq#(ix), Arith#(ix));
     Reg#(ix) clearCount <- mkReg(0);
     PulseWire didUpdate <- mkPulseWire;
     rule doClear(clearReg && !didUpdate);
-        for (Integer i = 0; i < a; i = i + 1) mem[i].upd(clearCount, unpack(0));
+        for (Integer i = 0; i < a; i = i + 1) mem[i].upd(clearCount, default_value);
         clearCount <= clearCount + 1;
         if (clearCount == ~0) clearReg <= False;
     endrule

--- a/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
@@ -491,6 +491,32 @@ module mkSpecFifo_SB_deq_enq_C_deq_enq#(Bool lazyEnq)(
     return m;
 endmodule
 
+
+// deq < enq (< correctSpec)
+// wrongSpec C enq
+// wrongSpec C deq
+typedef SpecFifo#(
+    size, t, 2, 2
+) SpecFifo_SB_enq_deq_C_enq_deq#(numeric type size, type t);
+
+module mkSpecFifo_SB_enq_deq_C_enq_deq(
+    SpecFifo_SB_deq_enq_C_deq_enq#(size, t)
+) provisos(Bits#(t, w), FShow#(t));
+    let sched = SpecFifoSched {
+        validDeqPort: 1,
+        validEnqPort: 0,
+        validWrongSpecPort: 0,
+        sbDeqPort: 0,
+        sbEnqPort: 0,
+        sbWrongSpecPort: 0,
+        wrongSpec_conflict_enq: True,
+        wrongSpec_conflict_deq: True,
+        wrongSpec_conflict_canon: True // acutally canon never fire
+    };
+    let m <- mkSpecFifo(sched, True);
+    return m;
+endmodule
+
 module mkSpecFifoUG#(Bool lazyEnq)(
     SpecFifo#(size, t, validPortNum, sbPortNum)
 ) provisos (

--- a/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/SpecFifo.bsv
@@ -1,4 +1,5 @@
 
+
 // Copyright (c) 2017 Massachusetts Institute of Technology
 //
 // Permission is hereby granted, free of charge, to any person
@@ -24,11 +25,11 @@
 import ProcTypes::*;
 import HasSpecBits::*;
 import Vector::*;
-import ConfigReg::*;
 import Ehr::*;
 import DReg::*;
 import Assert::*;
 import Types::*;
+import ConfigReg::*;
 
 typedef struct {
     t data;
@@ -41,6 +42,7 @@ interface SpecFifo#(
     numeric type sbPortNum // specBits EHR port num
 );
     method Action enq(ToSpecFifo#(t) x);
+    method Bool notFull;
     method Action deq;
     method ToSpecFifo#(t) first;
     method Bool notEmpty;
@@ -89,7 +91,22 @@ module mkSpecFifo#(
     Reg#(idxT) deqP = deqP_ehr[0]; // port 0 is for deq and canon_deqP
 
     // make incorrectSpeculation conflict with others
-    PulseWire wrongSpec_conflict <- mkPulseWire;
+    PulseWire dummyPulseWire = interface PulseWire;
+        method Bool _read = False;
+        method Action send = noAction;
+    endinterface;
+    PulseWire wrongSpec_enq_conflict = dummyPulseWire;
+    PulseWire wrongSpec_deq_conflict = dummyPulseWire;
+    PulseWire wrongSpec_canon_conflict = dummyPulseWire;
+    if(sched.wrongSpec_conflict_enq) begin
+        wrongSpec_enq_conflict <- mkPulseWire;
+    end
+    if(sched.wrongSpec_conflict_deq) begin
+        wrongSpec_deq_conflict <- mkPulseWire;
+    end
+    if(sched.wrongSpec_conflict_canon) begin
+        wrongSpec_canon_conflict <- mkPulseWire;
+    end
 
     function idxT getNextPtr(idxT p);
         return p == fromInteger(valueOf(size) - 1) ? 0 : p + 1;
@@ -97,7 +114,7 @@ module mkSpecFifo#(
 
     Bool empty_for_canon = all( \== (False) , readVEhr(sched.validDeqPort, valid) );
     rule canon_deqP(!valid[deqP][sched.validDeqPort] && (enqP != deqP || !empty_for_canon)
-                     && !wrongSpec_conflict); // make conflict with incorrect spec
+                     && !wrongSpec_canon_conflict); // make conflict with incorrect spec
         // element at deqP was killed, so increment deqP
         deqP <= getNextPtr(deqP);
     endrule
@@ -130,7 +147,7 @@ module mkSpecFifo#(
     end
 
     method Action enq(ToSpecFifo#(t) x) if ((empty_for_enq || enqP != deqP_for_enq)
-                                            && !wrongSpec_conflict); // make conflict with incorrect spec
+                                            && !wrongSpec_enq_conflict); // make conflict with incorrect spec
         // [sizhuo] I don't think valid bit needs to be checked here
         doAssert(!valid_for_enq, "enq entry cannot be valid");
         enqP <= getNextPtr(enqP);
@@ -139,8 +156,10 @@ module mkSpecFifo#(
         specBits[enqP][sched.sbEnqPort] <= x.spec_bits;
     endmethod
 
+    method Bool notFull = (empty_for_enq || enqP != deqP_for_enq);
+
     method Action deq if (valid[deqP][sched.validDeqPort]
-                          && !wrongSpec_conflict); // make conflict with incorrect spec
+                          && !wrongSpec_deq_conflict); // make conflict with incorrect spec
         valid[deqP][sched.validDeqPort] <= False;
         deqP <= getNextPtr(deqP);
     endmethod
@@ -180,7 +199,9 @@ module mkSpecFifo#(
             Vector#(size, Integer) idxVec = genVector;
             joinActions(map(incorrectSpec, idxVec));
             // make conflict with others
-            wrongSpec_conflict.send;
+            wrongSpec_enq_conflict.send;
+            wrongSpec_canon_conflict.send;
+            wrongSpec_deq_conflict.send;
         endmethod
     endinterface
 endmodule
@@ -212,14 +233,12 @@ module mkSpecFifoCF#(
     Reg#(idxT) enqP <- mkConfigReg(0);
     Ehr#(2, idxT) deqP_ehr <- mkEhr(0);
     Reg#(idxT) deqP = deqP_ehr[0]; // port 0 is for deq and canon_deqP
-    PulseWire enq_wr <- mkPulseWire;
-
 
     function idxT getNextPtr(idxT p);
         return p == fromInteger(valueOf(size) - 1) ? 0 : p + 1;
     endfunction
 
-    Bool empty_for_canon = all( \== (False) , valid[1] );
+    Bool empty_for_canon = all( \== (False) , valid[0] );
     rule canon_deqP(!valid[1][deqP] && (enqP != deqP || !empty_for_canon));
         // element at deqP was killed, so increment deqP
         deqP <= getNextPtr(deqP);
@@ -246,16 +265,10 @@ module mkSpecFifoCF#(
         valid[0] <= newValid;
     endrule
 
-    // Allow enq to schedule independently of deq.
-    rule enqValidCanon(enq_wr);
-        valid[2][enqP] <= True;
-    endrule
-
     // calculate guard for enq, we can do aggressively or lazily
     idxT deqP_for_enq = ?;
     Bool empty_for_enq = ?;
     Bool valid_for_enq = ?;
-    Integer enq_port = ?;
     if(lazyEnq) begin
         // use the stale deqP & valid before canon_deqP or deq fires
         // because deq, canon_deqP, wrongSpec only set valid to false and move deqP forward
@@ -272,23 +285,23 @@ module mkSpecFifoCF#(
         deqP_for_enq = deqP_for_enq_wire;
         empty_for_enq = empty_for_enq_wire;
         valid_for_enq = valid_for_enq_wire;
-        enq_port = 1;
     end
     else begin
         deqP_for_enq = deqP_ehr[1]; // read up-to-date deqP
         empty_for_enq = all( \== (False) , valid[2] );
         valid_for_enq = valid[2][enqP];
-        enq_port = 2;
     end
 
     method Action enq(ToSpecFifo#(t) x) if (empty_for_enq || enqP != deqP_for_enq);
         // [sizhuo] I don't think valid bit needs to be checked here
         doAssert(!valid_for_enq, "enq entry cannot be valid");
         row[enqP] <= x.data;
-        enq_wr.send;
-        specBits[enq_port][enqP] <= x.spec_bits;
+        valid[2][enqP] <= True;
+        specBits[2][enqP] <= x.spec_bits;
         enqP <= getNextPtr(enqP);
     endmethod
+
+    method Bool notFull = (empty_for_enq || enqP != deqP_for_enq);
 
     method Action deq if (valid[1][deqP]);
         valid[1][deqP] <= False;
@@ -447,6 +460,7 @@ module mkSpecFifo_SB_deq_enq_SB_deq_wrong_C_enq#(Bool lazyEnq)(
         wrongSpec_conflict_canon: False
     };
     let m <- mkSpecFifo(sched, lazyEnq);
+    // let m <- mkSpecFifoCF(lazyEnq);
     return m;
 endmodule
 
@@ -473,5 +487,169 @@ module mkSpecFifo_SB_deq_enq_C_deq_enq#(Bool lazyEnq)(
         wrongSpec_conflict_canon: True // acutally canon never fire
     };
     let m <- mkSpecFifo(sched, lazyEnq);
+    // let m <- mkSpecFifoCF(lazyEnq);
     return m;
+endmodule
+
+module mkSpecFifoUG#(Bool lazyEnq)(
+    SpecFifo#(size, t, validPortNum, sbPortNum)
+) provisos (
+    Alias#(idxT, Bit#(TLog#(size))),
+    Bits#(t, _tsz),
+    FShow#(t)
+);
+    SpecFifo#(size, t, validPortNum, sbPortNum) m <- mkSpecFifoCF(lazyEnq);
+    RWire#(ToSpecFifo#(t)) first_w <- mkRWire;
+    RWire#(ToSpecFifo#(t)) enq_w <- mkRWire;
+    PulseWire deq_w <- mkPulseWire;
+
+    rule doFirst;
+        first_w.wset(m.first);
+    endrule
+
+    rule doDeq(deq_w);
+        m.deq;
+    endrule
+
+    rule doEnq(enq_w.wget matches tagged Valid .e);
+        m.enq(e);
+    endrule
+
+    method enq = enq_w.wset;
+    method notFull = m.notFull;
+    method deq = deq_w.send;
+    method ToSpecFifo#(t) first = fromMaybe(?,first_w.wget);
+    method notEmpty = m.notEmpty;
+    interface SpeculationUpdate specUpdate = m.specUpdate;
+endmodule
+
+interface SearchableSpecFifo#(
+    numeric type size, type t,
+    type searchOut, type searchIn
+);
+    method Action enq(ToSpecFifo#(t) x);
+    method Action deq;
+    method ToSpecFifo#(t) first;
+    method Maybe#(searchOut) search(searchIn in);
+    interface SpeculationUpdate specUpdate;
+endinterface
+
+module mkSearchableSpecFifoCF#(
+    Bool lazyEnq, // whether we calculate enq guard lazily
+    Bool unguarded_insert, // only for probabalistic applications
+    function Maybe#(searchOut) search_f(searchIn w, t x)
+)(
+    SearchableSpecFifo#(size, t, searchOut, searchIn)
+) provisos (
+    Alias#(idxT, Bit#(TLog#(size))),
+    Bits#(t, _tsz),
+    FShow#(t)
+);
+    Ehr#(3, Vector#(size, Bool))             valid    <- mkEhr(replicate(False));
+    Vector#(size, Reg#(t))                   row      <- replicateM(mkConfigRegU);
+    Ehr#(3, Vector#(size, SpecBits))         specBits <- mkEhr(?);
+
+    Reg#(Maybe#(SpecBits))                correctSpec <- mkDReg(Invalid);
+    Reg#(Maybe#(IncorrectSpeculation))  incorrectSpec <- mkDReg(Invalid);
+
+    Reg#(idxT) enqP <- mkConfigReg(0);
+    Ehr#(2, idxT) deqP_ehr <- mkEhr(0);
+    Reg#(idxT) deqP = deqP_ehr[0]; // port 0 is for deq and canon_deqP
+
+    function idxT getNextPtr(idxT p);
+        return p == fromInteger(valueOf(size) - 1) ? 0 : p + 1;
+    endfunction
+
+    Bool empty_for_canon = all( \== (False) , valid[0] );
+    rule canon_deqP(!valid[1][deqP] && (enqP != deqP || !empty_for_canon));
+        // element at deqP was killed, so increment deqP
+        deqP <= getNextPtr(deqP);
+    endrule
+
+    (* fire_when_enabled, no_implicit_conditions *)
+    rule canon_speculation;
+        Vector#(size, SpecBits) newSpecBits = specBits[0];
+        Vector#(size, Bool) newValid = valid[0];
+        // Fold in CorrectSpec update:
+        if (correctSpec matches tagged Valid .mask) begin
+            // clear spec bits for all entries
+            for (Integer i=0; i<valueOf(size); i=i+1)
+                newSpecBits[i] = newSpecBits[i] & mask;
+        end
+        // Fold in IncorrectSpec update:
+        if (incorrectSpec matches tagged Valid .incSpec) begin
+            // clear entries
+            for (Integer i=0; i<valueOf(size); i=i+1)
+                if(incSpec.kill_all || newSpecBits[i][incSpec.specTag] == 1'b1)
+                    newValid[i] = False;
+        end
+        specBits[0] <= newSpecBits;
+        valid[0] <= newValid;
+    endrule
+
+    // calculate guard for enq, we can do aggressively or lazily
+    idxT deqP_for_enq = ?;
+    Bool empty_for_enq = ?;
+    Bool valid_for_enq = ?;
+    if(lazyEnq) begin
+        // use the stale deqP & valid before canon_deqP or deq fires
+        // because deq, canon_deqP, wrongSpec only set valid to false and move deqP forward
+        // this just makes enq fire less aggressively
+        Wire#(idxT) deqP_for_enq_wire <- mkBypassWire;
+        Wire#(Bool) empty_for_enq_wire <- mkBypassWire;
+        Wire#(Bool) valid_for_enq_wire <- mkBypassWire;
+        (* fire_when_enabled, no_implicit_conditions *)
+        rule setWireForEnq;
+            deqP_for_enq_wire <= deqP;
+            empty_for_enq_wire <= all( \== (False) , valid[1] );
+            valid_for_enq_wire <= valid[1][enqP];
+        endrule
+        deqP_for_enq = deqP_for_enq_wire;
+        empty_for_enq = empty_for_enq_wire;
+        valid_for_enq = valid_for_enq_wire;
+    end
+    else begin
+        deqP_for_enq = deqP_ehr[1]; // read up-to-date deqP
+        empty_for_enq = all( \== (False) , valid[2] );
+        valid_for_enq = valid[2][enqP];
+    end
+
+    Bool notFull = empty_for_enq || enqP != deqP_for_enq;
+    method Action enq(ToSpecFifo#(t) x) if (notFull || unguarded_insert);
+        if (notFull) begin
+            // [sizhuo] I don't think valid bit needs to be checked here
+            doAssert(!valid_for_enq, "enq entry cannot be valid");
+            row[enqP] <= x.data;
+            valid[2][enqP] <= True;
+            specBits[2][enqP] <= x.spec_bits;
+            enqP <= getNextPtr(enqP);
+        end
+    endmethod
+
+    method Action deq if (valid[1][deqP]);
+        valid[1][deqP] <= False;
+        deqP <= getNextPtr(deqP);
+    endmethod
+
+    method ToSpecFifo#(t) first if (valid[1][deqP]);
+        return ToSpecFifo{
+            data: row[deqP],
+            spec_bits: specBits[1][deqP]
+        };
+    endmethod
+
+    method Maybe#(searchOut) search(searchIn in);
+        Maybe#(searchOut) ret = Invalid;
+        for(Integer i = 0; i < valueOf(size); i = i + 1)
+            if (valid[0][i])
+                if (search_f(in, row[i]) matches tagged Valid .y)
+                    ret = Valid(y);
+        return ret;
+    endmethod
+
+    interface SpeculationUpdate specUpdate;
+        method correctSpeculation(mask) = correctSpec._write(Valid(mask));
+        method incorrectSpeculation(kill_all, specTag) =
+            incorrectSpec._write(Valid(IncorrectSpeculation{kill_all: kill_all, specTag: specTag}));
+    endinterface
 endmodule


### PR DESCRIPTION
This is a batch of changes to optimize memory latency, which was unusually high on Toooba.  This set eliminates two cycles of latency for Instruction L1 cache hits, and one cycle of latency for data L1 cache hits.  These changes improve performance by about 10%.  They have been tested to boot FreeBSD on vcu118 at 25MHz.  In addition, a version of these changes on the CHERI branch of Toooba were tested at ~47MHz on the Terasic DE10, and do not decrease frequency there.  (There is also a change to eliminate another cycle of latency from the data side, but that one affected frequency and is not included. This should be possible with a proper micro-TLB for data, as we now have for instruction.)