### PR TITLE
Master prefetch cleanup

### DIFF
--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -60,7 +60,7 @@ BSC_COMPILATION_FLAGS += \
 	-keep-fires -aggressive-conditions -no-warn-action-shadowing -check-assert \
 	-suppress-warnings G0020 -steps-max-intervals 10000000   \
 	-steps-warn-interval 1000000 \
-	+RTS -K128M -RTS  -show-range-conflict -show-schedule
+	+RTS -K128M -RTS  -show-range-conflict
 
 # ================================================================
 # Runs simulation executable on ELF given by EXAMPLE

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -60,7 +60,7 @@ BSC_COMPILATION_FLAGS += \
 	-keep-fires -aggressive-conditions -no-warn-action-shadowing -check-assert \
 	-suppress-warnings G0020 -steps-max-intervals 10000000   \
 	-steps-warn-interval 1000000 \
-	+RTS -K128M -RTS  -show-range-conflict
+	+RTS -K128M -RTS  -show-range-conflict -show-schedule
 
 # ================================================================
 # Runs simulation executable on ELF given by EXAMPLE

--- a/src_SSITH_P3/xilinx_ip/component.xml
+++ b/src_SSITH_P3/xilinx_ip/component.xml
@@ -2536,6 +2536,11 @@
         <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
       </spirit:file>
       <spirit:file>
+        <spirit:name>hdl/mkDPipeline.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+        <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
+      </spirit:file>
+      <spirit:file>
         <spirit:name>hdl/mkDivExecQ.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
         <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
@@ -3139,6 +3144,11 @@
       </spirit:file>
       <spirit:file>
         <spirit:name>hdl/mkDirPredictor.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+        <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>hdl/mkL1DPrefetcher.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
         <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
       </spirit:file>


### PR DESCRIPTION
Synthesise the prefetcher as a separate module, and honor the "always_ready" pragma by using an unguarded fifo for training data.

Also, make debug prints in the prefetcher optional, and off by default.

This was inspired by an issue where a branch was not prefetching at all due to what was likely and arbitrary scheduling decision.  Tweaking the FIFO types (non Bypass), removing debug prints, and synthesizing independently resolved the issue and should make the design much more stable scheduling-wise.