### PR TITLE
Remove reliance on generalization of implicitly typed let bindings

### DIFF
--- a/src_Core/CPU/CsrFile.bsv
+++ b/src_Core/CPU/CsrFile.bsv
@@ -342,8 +342,8 @@ module mkCsrFile #(Data hartid)(CsrFile);
     RiscVISASubset isa = defaultValue;
 
     // To save from bypassing logic, CSR reads will get stale value
-    let mkCsrReg = mkConfigReg;
-    let mkCsrEhr = mkConfigEhr;
+    function module#(Reg#(Bit#(n))) mkCsrReg(Bit#(n) i) = mkConfigReg(i);
+    function module#(Ehr#(2, Bit#(n))) mkCsrEhr(Bit#(n) i) = mkConfigEhr(i);
 
     // current prv level (this is not a csr...)
     Reg#(Bit#(2)) prv_reg <- mkCsrReg(prvM);

--- a/src_Core/RISCY_OOO/procs/lib/Exec.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Exec.bsv
@@ -234,7 +234,9 @@ function Bool memAddrMisaligned(Addr addr, ByteEn byteEn);
 endfunction
 
 function Data gatherLoad(Addr addr, ByteEn byteEn, Bool unsignedLd, Data data);
-    function extend = unsignedLd ? zeroExtend : signExtend;
+    function Data extend(Bit#(n) w) provisos (Add#(n,pad,SizeOf#(Data)));
+        return (unsignedLd ? zeroExtend(w) : signExtend(w));
+    endfunction
     Bit#(IndxShamt) offset = truncate(addr);
 
     if(byteEn[7]) begin


### PR DESCRIPTION
PR b-lang-org/bsc#902 proposes to turn off generalization of implicit let bindings by default in BSC, and in that case Toooba would fail to build.  We could add the hidden flag `-let-gen` to turn it on, but better would be to not rely on this feature, by adding explicit general types in the two places that need it.